### PR TITLE
Update validator commands for keymanager

### DIFF
--- a/docs/activating-a-validator.md
+++ b/docs/activating-a-validator.md
@@ -100,20 +100,20 @@ Open a second terminal window. Depending on your platform, issue the appropriate
 docker run -it -v $HOME/prysm/validator:/data --network="host" \
   gcr.io/prysmaticlabs/prysm/validator:latest \
   --beacon-rpc-provider=127.0.0.1:4000 \
-  --keystore-path=/data \
-  --password=changeme
+  --keymanager=keystore \
+  --keymanageropts='{"path":"/data","passphrase":"changeme"}'
 ```
 
 #### Starting the validator client with Docker on Windows
 
 ```text
-docker run -it -v $HOME/prysm/validator:/data --network="host" gcr.io/prysmaticlabs/prysm/validator:latest --beacon-rpc-provider=127.0.0.1:4000 --keystore-path=/data --password=changeme
+docker run -it -v $HOME/prysm/validator:/data --network="host" gcr.io/prysmaticlabs/prysm/validator:latest --beacon-rpc-provider=127.0.0.1:4000 --keymanager=keystore --keymanageropts='{"path":"/data","passphrase":"changeme"}'
 ```
 
 #### Starting the validator client with Bazel
 
 ```text
-bazel run //validator -- --keystore-path=$HOME/beacon-chain --password=changeme
+bazel run //validator -- --keymanager=keystore --keymanageropts='{"path":"'${HOME}'/beacon-chain","passphrase":"changeme"}'
 ```
 
 ## Submitting the deposit contract

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -190,7 +190,7 @@ bazel run //beacon-chain -- \
 Wait a moment for the beacon chain to start. In the other terminal, issue the command:
 
 ```text
-bazel run //validator -- --interop-num-validators 64
+bazel run //validator -- --keymanager=interop --keymanageropts='{"keys":64}'
 ```
 
 This command will kickstart the system with your 64 validators performing their duties accordingly.


### PR DESCRIPTION
Validator now uses keymanager; individual options are deprecated.  This updates the document to reflect the new usage.