### PR TITLE
Do Not Recommend Plaintext Password As Flag

### DIFF
--- a/docs/install/arm/activating-a-validator.md
+++ b/docs/install/arm/activating-a-validator.md
@@ -27,13 +27,13 @@ Step 3 requires running a command to generate a public / private keypair for you
 ```bash
 docker run -it -v $HOME/prysm/validator:/data \
    gcr.io/prysmaticlabs/prysm/validator:latest \
-   accounts create --keystore-path=/data --password=changeme
+   accounts create --keystore-path=/data
 ```
 
 #### Generating with Bazel
 
 ```text
-bazel run //validator -- accounts create --keystore-path=$HOME/beacon-chain --password=changeme
+bazel run //validator -- accounts create --keystore-path=$HOME/beacon-chain
 ```
 
 This command will output a `Raw Transaction Data` block:

--- a/docs/install/lin/activating-a-validator.md
+++ b/docs/install/lin/activating-a-validator.md
@@ -27,13 +27,13 @@ Step 3 requires running a command to generate a public / private keypair for you
 ```bash
 docker run -it -v $HOME/prysm/validator:/data \
    gcr.io/prysmaticlabs/prysm/validator:latest \
-   accounts create --keystore-path=/data --password=changeme
+   accounts create --keystore-path=/data 
 ```
 
 #### Generating with Bazel
 
 ```text
-bazel run //validator -- accounts create --keystore-path=$HOME/prysm/validator --password=changeme
+bazel run //validator -- accounts create --keystore-path=$HOME/prysm/validator
 ```
 
 This command will output a `Raw Transaction Data` block:

--- a/docs/install/mac/activating-a-validator.md
+++ b/docs/install/mac/activating-a-validator.md
@@ -27,13 +27,13 @@ Step 3 requires running a command to generate a public / private keypair for you
 ```bash
 docker run -it -v $HOME/prysm/validator:/data \
    gcr.io/prysmaticlabs/prysm/validator:latest \
-   accounts create --keystore-path=/data --password=changeme
+   accounts create --keystore-path=/data
 ```
 
 #### Generating with Bazel
 
 ```text
-bazel run //validator -- accounts create --keystore-path=$HOME/beacon-chain --password=changeme
+bazel run //validator -- accounts create --keystore-path=$HOME/beacon-chain
 ```
 
 This command will output a `Raw Transaction Data` block:

--- a/docs/install/win/activating-a-validator.md
+++ b/docs/install/win/activating-a-validator.md
@@ -27,19 +27,19 @@ Step 3 requires running a command to generate a public / private keypair for you
 ```bash
 docker run -it -v $HOME/prysm/validator:/data \
    gcr.io/prysmaticlabs/prysm/validator:latest \
-   accounts create --keystore-path=/data --password=changeme
+   accounts create --keystore-path=/data
 ```
 
 #### Generating with Docker on Windows
 
 ```text
-docker run -it -v c:/prysm:/data gcr.io/prysmaticlabs/prysm/validator:latest accounts create --keystore-path=/data --password=changeme
+docker run -it -v c:/prysm:/data gcr.io/prysmaticlabs/prysm/validator:latest accounts create --keystore-path=/data
 ```
 
 #### Generating with Bazel
 
 ```text
-bazel run //validator -- accounts create --keystore-path=$HOME/beacon-chain --password=changeme
+bazel run //validator -- accounts create --keystore-path=$HOME/beacon-chain
 ```
 
 This command will output a `Raw Transaction Data` block:

--- a/docs/prysm-usage/activating-a-validator.md
+++ b/docs/prysm-usage/activating-a-validator.md
@@ -27,19 +27,19 @@ Step 3 requires running a command to generate a public / private keypair for you
 ```bash
 docker run -it -v $HOME/prysm/validator:/data \
    gcr.io/prysmaticlabs/prysm/validator:latest \
-   accounts create --keystore-path=/data --password=changeme
+   accounts create --keystore-path=/data
 ```
 
 #### Generating with Docker on Windows
 
 ```text
-docker run -it -v c:/prysm:/data gcr.io/prysmaticlabs/prysm/validator:latest accounts create --keystore-path=/data --password=changeme
+docker run -it -v c:/prysm:/data gcr.io/prysmaticlabs/prysm/validator:latest accounts create --keystore-path=/data
 ```
 
 #### Generating with Bazel
 
 ```text
-bazel run //validator -- accounts create --keystore-path=$HOME/beacon-chain --password=changeme
+bazel run //validator -- accounts create --keystore-path=$HOME/beacon-chain
 ```
 
 This command will output a `Raw Transaction Data` block:


### PR DESCRIPTION
See: https://github.com/prysmaticlabs/prysm/issues/5434

```
the terminal command ./prysm.sh validator accounts create --keystore-path=$HOME/validator --password= is saved in terminal history and can be retrieved easily.

it will be better to advise users to write the command ./prysm.sh validator accounts create --keystore-path=$HOME/validator and enter those values as inputs
```
This PR removes all instances of recommending setting passwords this way