### PR TITLE
Minor update to running prysm.h install command

### DIFF
--- a/docs/install/windows.md
+++ b/docs/install/windows.md
@@ -57,7 +57,7 @@ reg add HKCU\Console /v VirtualTerminalLevel /t REG_DWORD /d 1
 4. Run the `prysm.sh` script alongside any [startup parameters](/docs/prysm-usage/parameters):
 
 ```sh
-.\prysm.sh beacon-chain --clear-db
+.\prysm.sh beacon-chain
 ```
 
 It is also recommended to include the `--p2p-host-ip` and `--min-sync-peers 7` flags to improve peering. For advanced users that desire standard debugging tools found in the Busybox base image, append a `--debug` flag to enable them.


### PR DESCRIPTION
Following a chat in Discord as I experienced a slight confusion following the setup guide:

SalohcinToday at 9:53 PM
Hi I'm following this guide https://docs.prylabs.network/docs/install/windows/ and after running the line in step 4, windows comes up with the following:

Starting Prysm beacon-chain --clear-db --min-sync-peers 7
2020/04/24 21:49:18 maxprocs: Leaving GOMAXPROCS=12: CPU quota undefined
time="2020-04-24 21:49:18" level=warning msg="Using default mainnet config" prefix=flags
time="2020-04-24 21:49:18" level=warning msg="This will delete your beacon chain data base stored in your data directory. Your database backups will not be removed - do you want to proceed? (Y/N)" prefix=node
>> n

I tried saying 'Y' but then the installer just exits, but now I tried with 'N' and it continues. Is that weird or am I not getting it?
Installing Prysm on Windows · Prysm 'Topaz' Testnet
Prysm can be installed on Windows systems using the Prysm build script. This page includes instructions for performing this process.

Ocaa/GrumsToday at 9:58 PM
@Salohcin the flag --clear-db shouldn't be in the command. This is only if your beacon chain db is corrupt or after a major update of the prysm client that you'll need to use this flag

SalohcinToday at 9:59 PM
Ah okay, so maybe it shouldn't be in the install guide?

Ocaa/GrumsToday at 9:59 PM
--clear-db will erase the whole sync of your node from the beacon chain, and you don't want to restart the sync from the beginning each time you restart your node

SalohcinToday at 9:59 PM
Yeah that would be a waste :slight_smile:

Ocaa/GrumsToday at 10:00 PM
@Salohcin I think so yeah. That's a mistake in the doc I think @celeste