### PR TITLE
Update instructions for windows to use prysm.bat (See Issue #5624)

### DIFF
--- a/docs/install/windows.md
+++ b/docs/install/windows.md
@@ -26,12 +26,9 @@ These hardware specifications are recommended, but not required to run the Prysm
 * Internet: Broadband connection
 .
 
-
-  > **NOTICE:** The `git` package for windows must be installed. It can be found [here](https://git-scm.com/download/win).
-
 ## Installing the beacon chain and validator
 
-The easiest way to install the beacon chain and validator is by running the `prysm.sh` script found in the main directory of the [Prysm repository](https://github.com/prysmaticlabs/prysm). This script will download and start up the latest release of Prysm binaries compatible with the host system.
+The easiest way to install the beacon chain and validator is by running the `prysm.bat` script found in the main directory of the [Prysm repository](https://github.com/prysmaticlabs/prysm). This script will download and start up the latest release of Prysm binaries compatible with the host system.
 
 > **NOTICE:** It is recommended to open up port 13000 on your local router to improve connectivity and receive more peers from the network. To do so, navigate to `192.168.0.1` in your browser and login if required. Follow along with the interface to modify your routers firewall settings. When this task is completed, append the parameter`--p2p-host-ip=$(curl -s ident.me)` to your selected beacon startup command presented in this section to use the newly opened port.
 
@@ -43,10 +40,10 @@ The easiest way to install the beacon chain and validator is by running the `pry
 mkdir prysm && cd prysm
 ```
 
-2. Fetch the `prysm.sh` script from Github and make it executable:
+2. Fetch the `prysm.bat` script from Github:
 
 ```sh
-curl https://raw.githubusercontent.com/prysmaticlabs/prysm/master/prysm.sh --output prysm.sh && chmod +x prysm.sh
+curl https://raw.githubusercontent.com/prysmaticlabs/prysm/master/prysm.bat --output prysm.bat
 ```
 
 3. To ensure logging appears properly, issue the following command:
@@ -54,29 +51,28 @@ curl https://raw.githubusercontent.com/prysmaticlabs/prysm/master/prysm.sh --out
 reg add HKCU\Console /v VirtualTerminalLevel /t REG_DWORD /d 1
 ``` 
 
-4. Run the `prysm.sh` script alongside any [startup parameters](/docs/prysm-usage/parameters):
+4. Run the `prysm.bat` script alongside any [startup parameters](/docs/prysm-usage/parameters):
 
 ```sh
-.\prysm.sh beacon-chain
+.\prysm.bat beacon-chain
 ```
 
 It is also recommended to include the `--p2p-host-ip` and `--min-sync-peers 7` flags to improve peering. For advanced users that desire standard debugging tools found in the Busybox base image, append a `--debug` flag to enable them.
 
-The `prysm.sh` script will now download and initialise the beacon chain with the specified parameters. The terminal will produce output like so:
+The `prysm.bat` script will now download and initialise the beacon chain with the specified parameters. The terminal will produce output like so:
 
 ```sh
-.\prysm.sh beacon-chain
-Latest Prysm version is v0.3.3.
-Downloading beacon chain@v0.3.3 to /home/{USER}/prysm/dist/beacon-chain-v0.3.3-linux-amd64 (automatically selected latest available version)
+.\prysm.bat beacon-chain
+Latest prysm release is v1.0.0-alpha.5.
+Using prysm version v1.0.0-alpha.5.
+Downloading beacon chain v1.0.0-alpha.5 to C:\Prysm\prysm\dist\validator-v1.0.0-alpha.5-windows-amd64.exe automatically selected latest available release
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
-100   622  100   622    0     0   2320      0 --:--:-- --:--:-- --:--:--  2312
-100 39.6M  100 39.6M    0     0  13.6M      0  0:00:02  0:00:02 --:--:-- 20.4M
-Downloading validator@v0.3.3 to /home/{USER}/prysm/dist/validator-v0.3.3-linux-amd64 (automatically selected latest available version)
-  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
-                                 Dload  Upload   Total   Spent    Left  Speed
-100   619  100   619    0     0   1484      0 --:--:-- --:--:-- --:--:--  1484
-100 32.5M  100 32.5M    0     0  12.6M      0  0:00:02  0:00:02 --:--:-- 21.7M
+100 40.3M  100 40.3M    0     0  4593k      0  0:00:09  0:00:09 --:--:-- 5177k
+WARN GPG verification is not natively available on Windows.
+WARN Skipping integrity verification of downloaded binary
+Verifying binary authenticity with SHA265 Hash.
+SHA265 Hash Match
 Starting Prysm beacon-chain
 ...
 ```
@@ -87,6 +83,12 @@ At this point, the beacon chain data will begin syncronising up to the latest he
 
 ## Staking ETH: Running a validator client
 
+5. Run the `prysm.bat` script to generate a new keypair, alongside any [startup parameters](/docs/prysm-usage/parameters):
+
+```sh
+.\prysm.bat validator accounts create --keystore-path=c:/prysm/validator --password=changeme
+```
+
 For step-by-step assistance with performing a deposit and setting up a validator client, see the [activating a validator ](/docs/install/win/activating-a-validator)section of this documentation.
 
 Once your beacon node is up, the chain will be waiting for you to deposit 32 Goerli ETH into a [validator deposit contract](/docs/prysm-usage/validator-deposit-contract) in order to activate your validator \(discussed in the section below\).
@@ -94,6 +96,28 @@ Once your beacon node is up, the chain will be waiting for you to deposit 32 Goe
 **If you need Goerli ETH**, follow the instructions found on [prylabs.network](https://prylabs.network) to use the testnet faucet. Otherwise, you can contact a team member on Discord to be sent some.
 
 Please note that **it may take up to 12 hours** for the nodes in the network to process a deposit. Once the node is active, the validator will immediately begin performing its responsibilities.
+
+6. Run the `prysm.bat` script alongside any [startup parameters](/docs/prysm-usage/parameters):
+
+```sh
+.\prysm.bat validator --keystore-path=c:/prysm/validator --password=changeme
+```
+
+```sh
+.\prysm.bat validator --keystore-path=c:/prysm/validator --password=changeme
+Latest prysm release is v1.0.0-alpha.5.
+Using prysm version v1.0.0-alpha.5.
+Downloading validator v1.0.0-alpha.5 to C:\Prysm\prysm\dist\validator-v1.0.0-alpha.5-windows-amd64.exe automatically selected latest available release
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+100 32.4M  100 32.4M    0     0  4747k      0  0:00:07  0:00:07 --:--:-- 5396k
+WARN GPG verification is not natively available on Windows.
+WARN Skipping integrity verification of downloaded binary
+Verifying binary authenticity with SHA265 Hash.
+SHA265 Hash Match
+Starting Prysm validator --keystore-path=c:/prysm/validator --password=changeme
+...
+```
 
 In your validator client, you will be able to frequently see your validator balance as it goes up over time. Note that, should your node ever go offline for a long period, a validator will start gradually losing its deposit until it is removed from the network entirely.
 


### PR DESCRIPTION
prysm.bat was proposed in https://github.com/prysmaticlabs/prysm/pull/5626 and behaves exactly like prysm.sh
Instructions from other OS's simply need to be modified to use Windows Paths.