### PR TITLE
Removed --password from all validator commands

### DIFF
--- a/docs/install/arm/activating-a-validator.md
+++ b/docs/install/arm/activating-a-validator.md
@@ -9,7 +9,7 @@ This section outlines the step-by-step process for ARM64 found on prylabs.net to
 ## Step 1: Get Prysm
 
 To begin, follow the instructions to fetch and install Prysm with either the [Prysm Installation Script](/docs/install/arm), or [Bazel](/docs/install/bazel).
-> NOTICE: Docker images are not currently generated for ARM64
+> **NOTICE:** Docker images are not currently generated for ARM64
 
 ## Step 2: Get Göerli ETH - Test ether
 
@@ -22,7 +22,7 @@ The wallet is scanned for the required amount of Göerli ETH after being linked.
 
 Depending on your platform, issue the appropriate command from the examples below to generate a public / private keypair for your validator.
 
-> NOTICE: When prompted, provide a password to encrypt your new ETH2 validator and withdrawl keys.
+> **NOTICE:** When prompted, provide a password to encrypt your new ETH2 validator and withdrawal keys.
 
 #### Generating with prysm.sh
 
@@ -78,7 +78,7 @@ The process of syncronising may take a while; the incoming block per second capa
 
 Open a second terminal window. Depending on your platform, issue the appropriate command from the examples below to start the validator.
 
-> NOTICE: When prompted, provide the password used to encrypt your ETH2 validator key.
+> **NOTICE:** When prompted, provide the password used to encrypt your ETH2 validator key.
 
 #### Starting the validator client with prysm.sh
 

--- a/docs/install/arm/activating-a-validator.md
+++ b/docs/install/arm/activating-a-validator.md
@@ -22,15 +22,18 @@ The wallet is scanned for the required amount of Göerli ETH after being linked.
 
 Depending on your platform, issue the appropriate command from the examples below to generate a public / private keypair for your validator.
 
+> NOTICE: When prompted, provide a password to encrypt your new ETH2 validator and withdrawl keys.
+
 #### Generating with prysm.sh
 
 ```text
-./prysm.sh validator accounts create --keystore-path=$HOME/.eth2validator --password=changeme
+./prysm.sh validator accounts create --keystore-path=$HOME/.eth2validator
 ```
+
 #### Generating with Bazel
 
 ```text
-bazel run //validator -- accounts create --keystore-path=$HOME/beacon-chain
+bazel run //validator -- accounts create --keystore-path=$HOME/prysm/validator
 ```
 
 This command will output a `Raw Transaction Data` block:
@@ -63,7 +66,7 @@ The beacon node is a long running process that will require a dedicated terminal
 bazel run //beacon-chain -- --datadir=$HOME/beacon-chain
 ```
 
-The beacon node will spin up and immediately begin communicating with the Prysm testnet, outputting data similar to the image below.
+The beacon-chain node will spin up and immediately begin communicating with the Prysm testnet, outputting data similar to the image below.
 
 ![](https://blobscdn.gitbook.com/v0/b/gitbook-28427.appspot.com/o/assets%2F-LRNnKRqTm4z1mzdDqDF%2F-Lua_6kBgtyMjsJFCSPr%2F-LuaaWo6lTgjk4e7WQ4p%2F9.png?alt=media&token=901b8c14-2a09-4365-bf63-1991c4996544)
 
@@ -75,10 +78,12 @@ The process of syncronising may take a while; the incoming block per second capa
 
 Open a second terminal window. Depending on your platform, issue the appropriate command from the examples below to start the validator.
 
+> NOTICE: When prompted, provide the password used to encrypt your ETH2 validator key.
+
 #### Starting the validator client with prysm.sh
 
 ```text
-./prysm.sh validator --keystore-path=$HOME/.eth2validator --password=changeme
+./prysm.sh validator --keystore-path=$HOME/.eth2validator
 ```
 
 #### Starting the validator client with Bazel

--- a/docs/install/lin/activating-a-validator.md
+++ b/docs/install/lin/activating-a-validator.md
@@ -21,7 +21,7 @@ The wallet is scanned for the required amount of Göerli ETH after being linked.
 
 Depending on your platform, issue the appropriate command from the examples below to generate a public / private keypair for your validator.
 
-> NOTICE: When prompted, provide a password to encrypt your new ETH2 validator and withdrawl keys.
+> **NOTICE:** When prompted, provide a password to encrypt your new ETH2 validator and withdrawal keys.
 
 #### Generating with prysm.sh
 

--- a/docs/install/lin/activating-a-validator.md
+++ b/docs/install/lin/activating-a-validator.md
@@ -21,6 +21,8 @@ The wallet is scanned for the required amount of Göerli ETH after being linked.
 
 Depending on your platform, issue the appropriate command from the examples below to generate a public / private keypair for your validator.
 
+> NOTICE: When prompted, provide a password to encrypt your new ETH2 validator and withdrawl keys.
+
 #### Generating with prysm.sh
 
 ```text
@@ -123,6 +125,8 @@ nano $HOME/prysm/validator/keystore.json
 > **NOTICE:** The beacon-chain node you are using should be **completely synced** before submitting your deposit. You may **incur minor inactivity balance penalties** if the validator is unable to perform its duties by the time the deposit is processed and activated by the ETH2 network.
 
 Open a second terminal window. Depending on your platform, issue the appropriate command from the examples below to start the validator.
+
+> NOTICE: When prompted, provide the password used to encrypt your ETH2 validator key.
 
 #### Starting the validator client with prysm.sh
 

--- a/docs/install/mac/activating-a-validator.md
+++ b/docs/install/mac/activating-a-validator.md
@@ -21,7 +21,7 @@ The wallet is scanned for the required amount of Göerli ETH after being linked.
 
 Depending on your platform, issue the appropriate command from the examples below to generate a public / private keypair for your validator.  
 
-> NOTICE: When prompted, provide a password to encrypt your new ETH2 validator and withdrawl keys.
+> **NOTICE:** When prompted, provide a password to encrypt your new ETH2 validator and withdrawal keys.
 
 #### Generating with prysm.sh
 
@@ -93,7 +93,7 @@ The process of syncronising may take a while; the incoming block per second capa
 
 Open a second terminal window. Depending on your platform, issue the appropriate command from the examples below to start the validator.
 
-> NOTICE: When prompted, provide the password used to encrypt your ETH2 validator key.
+> **NOTICE:** When prompted, provide the password used to encrypt your ETH2 validator key.
 
 #### Starting the validator client with prysm.sh
 

--- a/docs/install/mac/activating-a-validator.md
+++ b/docs/install/mac/activating-a-validator.md
@@ -21,10 +21,12 @@ The wallet is scanned for the required amount of Göerli ETH after being linked.
 
 Depending on your platform, issue the appropriate command from the examples below to generate a public / private keypair for your validator.  
 
+> NOTICE: When prompted, provide a password to encrypt your new ETH2 validator and withdrawl keys.
+
 #### Generating with prysm.sh
 
 ```text
-./prysm.sh validator accounts create --keystore-path=$HOME/.eth2validator --password=changeme
+./prysm.sh validator accounts create --keystore-path=$HOME/.eth2validator
 ```
 
 #### Generating with Docker
@@ -91,10 +93,12 @@ The process of syncronising may take a while; the incoming block per second capa
 
 Open a second terminal window. Depending on your platform, issue the appropriate command from the examples below to start the validator.
 
+> NOTICE: When prompted, provide the password used to encrypt your ETH2 validator key.
+
 #### Starting the validator client with prysm.sh
 
 ```text
-./prysm.sh validator --keystore-path=$HOME/.eth2validator --password=changeme
+./prysm.sh validator --keystore-path=$HOME/.eth2validator
 ```
 
 #### Starting the validator client with Docker

--- a/docs/install/win/activating-a-validator.md
+++ b/docs/install/win/activating-a-validator.md
@@ -22,16 +22,18 @@ The wallet is scanned for the required amount of Göerli ETH after being linked.
 
 Depending on your platform, issue the appropriate command from the examples below to generate a public / private keypair for your validator.
 
+> NOTICE: When prompted, provide a password to encrypt your new ETH2 validator and withdrawl keys.
+
 #### Generating with prysm.bat
 
 ```text
-prysm.bat validator accounts create --keystore-path=%USERPROFILE%\.eth2validator --password=changeme
+prysm.bat validator accounts create --keystore-path=%USERPROFILE%\.eth2validator
 ```
 
 #### Generating with Docker
 
 ```text
-docker run -it -v c:/prysm:/data gcr.io/prysmaticlabs/prysm/validator:latest accounts create --keystore-path=/data --password=changeme
+docker run -it -v c:/prysm:/data gcr.io/prysmaticlabs/prysm/validator:latest accounts create --keystore-path=/data
 ```
 
 This command will output a `Raw Transaction Data` block:
@@ -77,10 +79,12 @@ The process of syncronising may take a while; the incoming block per second capa
 
 Open a second Command Prompt window. Depending on your platform, issue the appropriate command from the examples below to start the validator.
 
+> NOTICE: When prompted, provide the password used to encrypt your ETH2 validator key.
+
 #### Starting the validator client with prysm.bat
 
 ```text
-prysm.bat validator --keystore-path=%USERPROFILE%\.eth2validator --password=changeme
+prysm.bat validator --keystore-path=%USERPROFILE%\.eth2validator
 ```
 
 #### Starting the validator client with Docker

--- a/docs/install/win/activating-a-validator.md
+++ b/docs/install/win/activating-a-validator.md
@@ -9,7 +9,7 @@ This section outlines the step-by-step process for Windows found on prylabs.net 
 ## Step 1: Get Prysm
 
 To begin, follow the instructions to fetch and install Prysm with either the [Prysm Installation Script](../windows), or [Docker](./docker).
-> NOTICE: Compiling Prysm with Bazel is not currently supported on Windows.
+> **NOTICE:** Compiling Prysm with Bazel is not currently supported on Windows.
 
 ## Step 2: Get Göerli ETH - Test ether
 
@@ -22,7 +22,7 @@ The wallet is scanned for the required amount of Göerli ETH after being linked.
 
 Depending on your platform, issue the appropriate command from the examples below to generate a public / private keypair for your validator.
 
-> NOTICE: When prompted, provide a password to encrypt your new ETH2 validator and withdrawl keys.
+> **NOTICE:** When prompted, provide a password to encrypt your new ETH2 validator and withdrawal keys.
 
 #### Generating with prysm.bat
 
@@ -79,7 +79,7 @@ The process of syncronising may take a while; the incoming block per second capa
 
 Open a second Command Prompt window. Depending on your platform, issue the appropriate command from the examples below to start the validator.
 
-> NOTICE: When prompted, provide the password used to encrypt your ETH2 validator key.
+> **NOTICE:** When prompted, provide the password used to encrypt your ETH2 validator key.
 
 #### Starting the validator client with prysm.bat
 

--- a/docs/install/windows.md
+++ b/docs/install/windows.md
@@ -81,7 +81,7 @@ At this point, the beacon chain data will begin syncronising up to the latest he
 
 5. Run the `prysm.bat` script to generate a new keypair, alongside any [startup parameters](/docs/prysm-usage/parameters):
 
-> NOTICE: When prompted, provide a password to encrypt your new ETH2 validator and withdrawl keys.
+> **NOTICE:** When prompted, provide a password to encrypt your new ETH2 validator and withdrawal keys.
 
 ```sh
 .\prysm.bat validator accounts create --keystore-path=c:/prysm/validator
@@ -97,7 +97,7 @@ Please note that **it may take up to 12 hours** for the nodes in the network to 
 
 6. Run the `prysm.bat` script alongside any [startup parameters](/docs/prysm-usage/parameters#validator-parameters):
 
-> NOTICE: When prompted, provide the password used to encrypt your ETH2 validator key.
+> **NOTICE:** When prompted, provide the password used to encrypt your ETH2 validator key.
 
 ```sh
 .\prysm.bat validator --keystore-path=%USERPROFILE%\.eth2validator

--- a/docs/install/windows.md
+++ b/docs/install/windows.md
@@ -81,8 +81,10 @@ At this point, the beacon chain data will begin syncronising up to the latest he
 
 5. Run the `prysm.bat` script to generate a new keypair, alongside any [startup parameters](/docs/prysm-usage/parameters):
 
+> NOTICE: When prompted, provide a password to encrypt your new ETH2 validator and withdrawl keys.
+
 ```sh
-.\prysm.bat validator accounts create --keystore-path=c:/prysm/validator --password=changeme
+.\prysm.bat validator accounts create --keystore-path=c:/prysm/validator
 ```
 
 For step-by-step assistance with performing a deposit and setting up a validator client, see the [activating a validator ](/docs/install/win/activating-a-validator)section of this documentation.
@@ -95,12 +97,14 @@ Please note that **it may take up to 12 hours** for the nodes in the network to 
 
 6. Run the `prysm.bat` script alongside any [startup parameters](/docs/prysm-usage/parameters#validator-parameters):
 
+> NOTICE: When prompted, provide the password used to encrypt your ETH2 validator key.
+
 ```sh
-.\prysm.bat validator --keystore-path=%USERPROFILE%\.eth2validator --password=changeme
+.\prysm.bat validator --keystore-path=%USERPROFILE%\.eth2validator
 ```
 
 ```sh
-.\prysm.bat validator --keystore-path=%USERPROFILE%\.eth2validator --password=changeme
+.\prysm.bat validator --keystore-path=%USERPROFILE%\.eth2validator
 Latest prysm release is v1.0.0-alpha.5.
 Using prysm version v1.0.0-alpha.5.
 Downloading validator v1.0.0-alpha.5 to .\dist\validator-v1.0.0-alpha.5-windows-amd64.exe automatically selected latest available release
@@ -111,7 +115,7 @@ WARN GPG verification is not natively available on Windows.
 WARN Skipping integrity verification of downloaded binary
 Verifying binary authenticity with SHA265 Hash.
 SHA265 Hash Match
-Starting Prysm validator --keystore-path=%USERPROFILE%\.eth2validator --password=changeme
+Starting Prysm validator --keystore-path=%USERPROFILE%\.eth2validator
 ...
 ```
 

--- a/docs/prysm-usage/p2p-host-ip.md
+++ b/docs/prysm-usage/p2p-host-ip.md
@@ -65,7 +65,7 @@ curl v4.ident.me
 ## Port forwarding
 Participants on home networks will need to configure their router to perform port forwarding so that other ETH2 participants can establish a connection to your [beacon node](/docs/how-prysm-works/beacon-node) on TCP/13000.  The specific steps required vary based on your router, but can be summarised as follows:
 
-> NOTICE : Participants with nodes on a virtual public cloud (VPC) instance can skip this step.
+> **NOTICE:** Participants with nodes on a virtual public cloud (VPC) instance can skip this step.
 
 1. Determine the IP address for your home router
 2. Browse to the managment website for your home router (typically http://192.168.1.1)

--- a/docs/prysm-usage/parameters.md
+++ b/docs/prysm-usage/parameters.md
@@ -103,7 +103,7 @@ These flags are specific to launching a validator client.
 |`--unencrypted-keys` | Filepath to a JSON file of unencrypted validator keys for easier launching of the validator client.
 |`--keymanager`| The keymanger to use (unencrypted, interop, keystore, wallet).
 |`--keymanageropts`| The options for the keymanger, either a JSON string or path to same.
-|`--password` | String value of the password for your validator private keys.
+|`--password` | String value of the password for your validator private keys. (Not recommended - your password may get logged in command history)
 |`--disable-rewards-penalties-logging` | Disable reward/penalty logging during cluster deployment.
 |`--graffiti` | A string to include in proposed block.
 |`--grpc-max-msg-size`| Integer to define max recieve message call size. <br>Default: 52428800 (for 50Mb).

--- a/docs/prysm-usage/slasher.md
+++ b/docs/prysm-usage/slasher.md
@@ -18,7 +18,7 @@ Slashable offenses include:
  
 
 ## Get Prysm and start beacon-chain
-> NOTICE: If beacon-chain is already running, skip to step 2 
+> **NOTICE:** If beacon-chain is already running, skip to step 2 
 
 1. To begin, follow the instructions for [GNU\Linux](../install/linux), [macOS](../install/mac), [ARM64](../install/arm), or [Windows](../install/windows) to fetch and install Prysm.  The beacon-chain process should be running and fully synced before proceeding.
 


### PR DESCRIPTION
The use of the --password flag should not be reccommended as this may result in passwords being logged to command history 
related #36