### PR TITLE
Add instructions to allow udp/12000

### DIFF
--- a/docs/install/arm/bazel.md
+++ b/docs/install/arm/bazel.md
@@ -47,7 +47,7 @@ Bazel will automatically pull and install any dependencies as well, including Go
 Below are instructions for initialising a beacon node and connecting to the public testnet. To further understand the role that the beacon node plays in Prysm, see [this section](/docs/how-prysm-works/overview-technical) of the documentation.
 
 
-   > **NOTICE:** It is recommended to open up port 13000 on your local router to improve connectivity and receive more peers from the network. To do so, navigate to `192.168.0.1` in your browser and login if required. Follow along with the interface to modify your routers firewall settings. When this task is completed, append the parameter`--p2p-host-ip=$(curl -s ident.me)` to your selected beacon startup command presented in this section to use the newly opened port.
+   > **NOTICE:** It is recommended to open up port tcp/13000 and udp/12000 on your local router to improve connectivity and receive more peers from the network. To do so, navigate to `192.168.0.1` in your browser and login if required. Follow along with the interface to modify your routers firewall settings. When this task is completed, append the parameter`--p2p-host-ip=$(curl -s ident.me)` to your selected beacon startup command presented in this section to use the newly opened port.
 
 
 To start your [beacon node](/docs/how-prysm-works/prysm-beacon-node) with Bazel, issue the following command:

--- a/docs/install/lin/activating-a-validator.md
+++ b/docs/install/lin/activating-a-validator.md
@@ -70,7 +70,7 @@ The beacon node is a long running process that will require a dedicated terminal
 #### Starting the beacon-chain node with Docker
 
 ```text
-docker run -it -v $HOME/prysm/beacon:/data -p 4000:4000 -p 13000:13000 \
+docker run -it -v $HOME/prysm/beacon:/data -p 4000:4000 -p 13000:13000 -p 12000:12000/udp \
   gcr.io/prysmaticlabs/prysm/beacon-chain:latest \
   --datadir=/data
 ```

--- a/docs/install/lin/bazel.md
+++ b/docs/install/lin/bazel.md
@@ -49,7 +49,7 @@ Bazel will automatically pull and install any dependencies as well, including Go
 Below are instructions for initialising a beacon node and connecting to the public testnet. To further understand the role that the beacon node plays in Prysm, see [this section](../how-prysm-works/overview-technical) of the documentation.
 
 
-   > **NOTICE:** It is recommended to open up port 13000 on your local router to improve connectivity and receive more peers from the network. To do so, navigate to `192.168.0.1` in your browser and login if required. Follow along with the interface to modify your routers firewall settings. When this task is completed, append the parameter`--p2p-host-ip=$(curl -s ident.me)` to your selected beacon startup command presented in this section to use the newly opened port.
+   > **NOTICE:** It is recommended to open up port tcp/13000 and udp/12000 on your local router to improve connectivity and receive more peers from the network. To do so, navigate to `192.168.0.1` in your browser and login if required. Follow along with the interface to modify your routers firewall settings. When this task is completed, append the parameter`--p2p-host-ip=$(curl -s ident.me)` to your selected beacon startup command presented in this section to use the newly opened port.
 
 
 To start your [beacon node](how-prysm-works/prysm-beacon-node) with Bazel, issue the following command:

--- a/docs/install/lin/docker.md
+++ b/docs/install/lin/docker.md
@@ -41,13 +41,13 @@ This process will also install any related dependencies.
 Below are instructions for initialising a beacon node and connecting to the public testnet. To further understand the role that the beacon node plays in Prysm, see [this section](/docs/how-prysm-works/architecture-overview/) of the documentation.
 
 
-   > **NOTICE:** It is recommended to open up port 13000 on your local router to improve connectivity and receive more peers from the network. To do so, navigate to `192.168.0.1` in your browser and login if required. Follow along with the interface to modify your routers firewall settings. When this task is completed, append the parameter`--p2p-host-ip=$(curl -s ident.me)` to your selected beacon startup command presented in this section to use the newly opened port.
+   > **NOTICE:** It is recommended to open up port tcp/13000 and udp/12000 on your local router to improve connectivity and receive more peers from the network. To do so, navigate to `192.168.0.1` in your browser and login if required. Follow along with the interface to modify your routers firewall settings. When this task is completed, append the parameter`--p2p-host-ip=$(curl -s ident.me)` to your selected beacon startup command presented in this section to use the newly opened port.
 
 
 To start your beacon node, issue the following command:
 
 ```text
-docker run -it -v $HOME/prysm:/data -p 4000:4000 -p 13000:13000 --name beacon-node \
+docker run -it -v $HOME/prysm:/data -p 4000:4000 -p 13000:13000 -p 12000:12000/udp --name beacon-node \
   gcr.io/prysmaticlabs/prysm/beacon-chain:latest \
   --datadir=/data
 ```
@@ -95,7 +95,7 @@ In your validator client, you will be able to frequently see your validator bala
   To recreate a deleted container and refresh the chain database, issue the start command with an additional `--clear-db` parameter:
 
   ```text
-  docker run -it -v $HOME/prysm:/data -p 4000:4000 -p 13000:13000 --name beacon-node \
+  docker run -it -v $HOME/prysm:/data -p 4000:4000 -p 13000:13000 -p 12000:12000/udp --name beacon-node \
     gcr.io/prysmaticlabs/prysm/beacon-chain:latest \
     --datadir=/data \
     --clear-db

--- a/docs/install/mac/activating-a-validator.md
+++ b/docs/install/mac/activating-a-validator.md
@@ -70,7 +70,7 @@ The beacon node is a long running process that will require a dedicated terminal
 #### Starting the beacon-chain node with Docker
 
 ```text
-docker run -it -v $HOME/prysm/beacon:/data -p 4000:4000 -p 13000:13000 \
+docker run -it -v $HOME/prysm/beacon:/data -p 4000:4000 -p 13000:13000 -p 12000:12000/udp \
   gcr.io/prysmaticlabs/prysm/beacon-chain:latest \
   --datadir=/data
 ```

--- a/docs/install/mac/bazel.md
+++ b/docs/install/mac/bazel.md
@@ -47,7 +47,7 @@ Bazel will automatically pull and install any dependencies as well, including Go
 Below are instructions for initialising a beacon node and connecting to the public testnet. To further understand the role that the beacon node plays in Prysm, see [this section](../how-prysm-works/overview-technical) of the documentation.
 
 
-   > **NOTICE:** It is recommended to open up port 13000 on your local router to improve connectivity and receive more peers from the network. To do so, navigate to `192.168.0.1` in your browser and login if required. Follow along with the interface to modify your routers firewall settings. When this task is completed, append the parameter`--p2p-host-ip=$(curl -s ident.me)` to your selected beacon startup command presented in this section to use the newly opened port.
+   > **NOTICE:** It is recommended to open up port tcp/13000 and udp/12000 on your local router to improve connectivity and receive more peers from the network. To do so, navigate to `192.168.0.1` in your browser and login if required. Follow along with the interface to modify your routers firewall settings. When this task is completed, append the parameter`--p2p-host-ip=$(curl -s ident.me)` to your selected beacon startup command presented in this section to use the newly opened port.
 
 
 To start your [beacon node](how-prysm-works/prysm-beacon-node) with Bazel, issue the following command:

--- a/docs/install/mac/docker.md
+++ b/docs/install/mac/docker.md
@@ -44,13 +44,13 @@ This process will also install any related dependencies.
 Below are instructions for initialising a beacon node and connecting to the public testnet. To further understand the role that the beacon node plays in Prysm, see [this section](../how-prysm-works/overview-technical) of the documentation.
 
 
-   > **NOTICE:** It is recommended to open up port 13000 on your local router to improve connectivity and receive more peers from the network. To do so, navigate to `192.168.0.1` in your browser and login if required. Follow along with the interface to modify your routers firewall settings. When this task is completed, append the parameter`--p2p-host-ip=$(curl -s ident.me)` to your selected beacon startup command presented in this section to use the newly opened port.
+   > **NOTICE:** It is recommended to open up port tcp/13000 and udp/12000 on your local router to improve connectivity and receive more peers from the network. To do so, navigate to `192.168.0.1` in your browser and login if required. Follow along with the interface to modify your routers firewall settings. When this task is completed, append the parameter`--p2p-host-ip=$(curl -s ident.me)` to your selected beacon startup command presented in this section to use the newly opened port.
 
 
 To start your beacon node, issue the following command:
 
 ```text
-docker run -it -v $HOME/prysm:/data -p 4000:4000 -p 13000:13000 --name beacon-node \
+docker run -it -v $HOME/prysm:/data -p 4000:4000 -p 13000:13000 -p 12000:12000/udp --name beacon-node \
   gcr.io/prysmaticlabs/prysm/beacon-chain:latest \
   --datadir=/data
 ```
@@ -98,7 +98,7 @@ In your validator client, you will be able to frequently see your validator bala
   To recreate a deleted container and refresh the chain database, issue the start command with an additional `--clear-db` parameter:
 
   ```text
-  docker run -it -v $HOME/prysm:/data -p 4000:4000 -p 13000:13000 --name beacon-node \
+  docker run -it -v $HOME/prysm:/data -p 4000:4000 -p 13000:13000 -p 12000:12000/udp --name beacon-node \
     gcr.io/prysmaticlabs/prysm/beacon-chain:latest \
     --datadir=/data \
     --clear-db

--- a/docs/install/win/activating-a-validator.md
+++ b/docs/install/win/activating-a-validator.md
@@ -63,7 +63,7 @@ prysm.bat beacon-chain --datadir=%APPDATA%\Eth2
 #### Starting the beacon-chain node with Docker
 
 ```text
-docker run -it -v c:/prysm/beacon:/data -p 4000:4000 -p 13000:13000 gcr.io/prysmaticlabs/prysm/beacon-chain:latest --datadir=/data
+docker run -it -v c:/prysm/beacon:/data -p 4000:4000 -p 13000:13000 -p 12000:12000/udp gcr.io/prysmaticlabs/prysm/beacon-chain:latest --datadir=/data
 ```
 
 

--- a/docs/install/win/docker.md
+++ b/docs/install/win/docker.md
@@ -35,7 +35,7 @@ This process will also install any related dependencies.
 
 > For advanced users, the beacon-chain and validator images with debugging tools bundled in can be fetched instead by appending `-alpine` to the end of the images in the `pull` commands above. For example: `docker pull .../prysm/validator:latest-alpine`.
 
-   > **NOTICE:** It is recommended to open up port 13000 on your local router to improve connectivity and receive more peers from the network. To do so, navigate to `192.168.0.1` in your browser and login if required. Follow along with the interface to modify your routers firewall settings. When this task is completed, append the parameter`--p2p-host-ip=$(curl -s ident.me)` to your selected beacon startup command presented in this section to use the newly opened port.
+   > **NOTICE:** It is recommended to open up port tcp/13000 and udp/12000 on your local router to improve connectivity and receive more peers from the network. To do so, navigate to `192.168.0.1` in your browser and login if required. Follow along with the interface to modify your routers firewall settings. When this task is completed, append the parameter`--p2p-host-ip=$(curl -s ident.me)` to your selected beacon startup command presented in this section to use the newly opened port.
 
 
 ## Connecting to the testnet: running a beacon node
@@ -52,7 +52,7 @@ Below are instructions for initialising a beacon node and connecting to the publ
 3. To run the beacon node, issue the following command:
 
 ```text
-docker run -it -v c:/prysm/:/data -p 4000:4000 -p 13000:13000 gcr.io/prysmaticlabs/prysm/beacon-chain:latest --datadir=/data --clear-db
+docker run -it -v c:/prysm/:/data -p 4000:4000 -p 13000:13000 -p 12000:12000/udp gcr.io/prysmaticlabs/prysm/beacon-chain:latest --datadir=/data --clear-db
 ```
 
 This will sync up the beacon node with the latest cannonical head block in the network. It is also recommended to include the `--p2p-host-ip` and `--min-sync-peers 7` flags to improve peering. The Docker `-d` flag can be appended before the `-v` flag to launch the process in a detached terminal window.
@@ -99,5 +99,5 @@ docker rm beacon-node
 To recreate a deleted container and refresh the chain database, issue the start command with an additional `--clear-db` parameter:
 
 ```text
-docker run -it -v $HOME/prysm:/data -p 4000:4000 -p 13000:13000 --name beacon-node gcr.io/prysmaticlabs/prysm/beacon-chain:latest --datadir=/data --clear-db
+docker run -it -v $HOME/prysm:/data -p 4000:4000 -p 13000:13000 -p 12000:12000/udp --name beacon-node gcr.io/prysmaticlabs/prysm/beacon-chain:latest --datadir=/data --clear-db
 ```

--- a/docs/prysm-usage/p2p-host-ip.md
+++ b/docs/prysm-usage/p2p-host-ip.md
@@ -26,7 +26,7 @@ Other participants on the ETH2 network operate their nodes on a virtual public c
 
 In order for other participants on the ETH2 network to establish incoming P2P connections with your [beacon node](/docs/how-prysm-works/beacon-node), a number of conditions must be met:
 1. Your public IP address must be known.
-2. The protocol (TCP/UDP) and port number (0-65535) on which your [beacon node](/docs/how-prysm-works/beacon-node) is listening must be known (Default - TCP/13000).
+2. The protocol (TCP/UDP) and port number (0-65535) on which your [beacon node](/docs/how-prysm-works/beacon-node) is listening must be known (Default - TCP/13000 and UDP/12000).
 3. All routers & firewalls must be configured to allow incoming traffic on that protocol/port combination.
 
 ## Private IP addresses
@@ -63,7 +63,7 @@ curl v4.ident.me
 ```
 
 ## Port forwarding
-Participants on home networks will need to configure their router to perform port forwarding so that other ETH2 participants can establish a connection to your [beacon node](/docs/how-prysm-works/beacon-node) on TCP/13000.  The specific steps required vary based on your router, but can be summarised as follows:
+Participants on home networks will need to configure their router to perform port forwarding so that other ETH2 participants can establish a connection to your [beacon node](/docs/how-prysm-works/beacon-node) on TCP/13000 and UDP/12000.  The specific steps required vary based on your router, but can be summarised as follows:
 
 > **NOTICE:** Participants with nodes on a virtual public cloud (VPC) instance can skip this step.
 
@@ -75,6 +75,11 @@ Participants on home networks will need to configure their router to perform por
     - External port: 13000
     - Internal port: 13000
     - Protocol: TCP
+    - IP Address: Private IP address of the computer running beacon-chain
+5. Configure a second port forwarding rule with the following values:
+    - External port: 12000
+    - Internal port: 12000
+    - Protocol: UDP
     - IP Address: Private IP address of the computer running beacon-chain
 
 There are many websites available with more detailed instructions on how to perform the steps above on your specific router. A quick search should help get you started.  Feel free to ask for help in our [Discord](https://discord.gg/YMVYzv6).
@@ -98,7 +103,7 @@ netstat -nr | grep default
 
 ## Firewalls
 
-Many computers have a local firewall that blocks incoming connections. Ensure that you have configured the firewall to allow incoming connections on TCP/13000 from all source IP addresses.
+Many computers have a local firewall that blocks incoming connections. Ensure that you have configured the firewall to allow incoming connections on TCP/13000 and UDP/12000 from all source IP addresses.
 
 ## Setting the `--p2p-host-ip` flag
 


### PR DESCRIPTION
Only TCP port 13000 was documented as being required for p2p.  discv5 uses UDP/12000 for discovery. Docker, port forwarding & firewall instructions updated to reflect this.

closes #60