### PR TITLE
Add Instructions for Public API Contributions

### DIFF
--- a/docs/contribute/contribution-guidelines.md
+++ b/docs/contribute/contribution-guidelines.md
@@ -83,6 +83,10 @@ You can also run our full, end-to-end test suite with:
 $ bazel test //endtoend:go_default_test --define=ssz=minimal
 ```
 
+### Contributing to the Eth2 API
+
+The eth2 API implemented by Prysm is maintained as a separate repository than Prysm. You can read more about how to contribute specifically to the API [here](/docs/how-prysm-works/ethereum-2-public-api#contributing).
+
 ### Running a local chain
 
 Although tests are the best and most simple way of ensuring your feature or bug fix contribution works, sometimes it can be helpful to run a real chain with your changes to ensure they are reflected at runtime. Here are some helpful commands to try running your own, local chain with 64 validators!
@@ -143,7 +147,7 @@ To fetch changes to the Prysm repository since your last session:
 $ git fetch origin
 ```
 
-Then synchronise your master branch:
+Then synchronize your master branch:
 
 ```text
 $ git pull origin master

--- a/docs/how-prysm-works/ethereum-2.0-public-api.md
+++ b/docs/how-prysm-works/ethereum-2.0-public-api.md
@@ -20,7 +20,7 @@ Prysm implements its API by using the popular [gRPC](https://grpc.io) project cr
 
 ## Contributing
 
-Thanks for wanting to contribute to our eth2 API! Go libraries may be generated from the [ethereumapis repository](https://github.com/prysmaticlabs/ethereumapis) using [Bazel](https://bazel.build), making it easy to make changes to the schemas needed and generate Go files from them. Here's what you need to get started:
+Thanks for wanting to contribute to our eth2 API! Go and Java libraries may be generated from the [ethereumapis repository](https://github.com/prysmaticlabs/ethereumapis) using [Bazel](https://bazel.build), making it easy to make changes to the schemas needed and generate Go files or Java packages from them. Here's what you need to get started:
 
 ### Dependencies
 


### PR DESCRIPTION
Our public APIs page was super outdated, and several users have come forth with great contributions to the api for eth2 despite us having to explain the whole contribution process to them first. This PR updates the page with instructions on using Bazel and how to implement the API changes in Prysm.