### PR TITLE
Add a subsection for monitoring

### DIFF
--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -32,7 +32,9 @@
 								"prysm-usage/wallet-keymanager",
 								"prysm-usage/slasher",
 								"prysm-usage/p2p-host-ip",
-								"prysm-usage/monitoring/grafana-dashboard",
+								"Monitoring":	[	"prysm-usage/monitoring/grafana-dashboard",
+											"prysm-usage/monitoring/currency-converter"
+										],
 								"faq"
 							],
 


### PR DESCRIPTION
I have no idea if this work... I'm sorry in advance if it doesn't. 

I want to add the currency-converter into the documentation, but to get better a organized menu, I think it would be better if it was in a subsection. If this isn't possible, then we could maybe create a brand new section?

I'm mostly trying to give ideas here