### PR TITLE
Added monitoring host and rpc host to docker instructions

### DIFF
--- a/website/docs/install/lin/docker.md
+++ b/website/docs/install/lin/docker.md
@@ -114,8 +114,9 @@ In your validator client, you will be able to frequently see your validator bala
 
   ```text
   docker run -it -v $HOME/.eth2:/data -p 4000:4000 -p 13000:13000 -p 12000:12000/udp --name beacon-node \
-
     gcr.io/prysmaticlabs/prysm/beacon-chain:latest \
     --datadir=/data \
-    --clear-db
+    --clear-db \
+    --rpc-host=0.0.0.0 \
+    --monitoring-host=0.0.0.0
   ```

--- a/website/docs/install/mac/docker.md
+++ b/website/docs/install/mac/docker.md
@@ -116,10 +116,10 @@ In your validator client, you will be able to frequently see your validator bala
   To recreate a deleted container and refresh the chain database, issue the start command with an additional `--clear-db` parameter:
 
   ```text
-
   docker run -it -v $HOME/.eth2:/data -p 4000:4000 -p 13000:13000 -p 12000:12000/udp --name beacon-node \
-
     gcr.io/prysmaticlabs/prysm/beacon-chain:latest \
     --datadir=/data \
-    --clear-db
+    --clear-db \
+    --rpc-host=0.0.0.0 \
+    --monitoring-host=0.0.0.0
   ```

--- a/website/docs/install/win/docker.md
+++ b/website/docs/install/win/docker.md
@@ -116,5 +116,5 @@ docker rm beacon-node
 To recreate a deleted container and refresh the chain database, issue the start command with an additional `--clear-db` parameter:
 
 ```text
-docker run -it -v %LOCALAPPDATA%\Eth2:/data -p 4000:4000 -p 13000:13000 -p 12000:12000/udp --name beacon-node gcr.io/prysmaticlabs/prysm/beacon-chain:latest --datadir=/data --clear-db
+docker run -it -v %LOCALAPPDATA%\Eth2:/data -p 4000:4000 -p 13000:13000 -p 12000:12000/udp --name beacon-node gcr.io/prysmaticlabs/prysm/beacon-chain:latest --datadir=/data --clear-db --monitoring-host=0.0.0.0 --rpc-host=0.0.0.0
 ```


### PR DESCRIPTION
This PR adds the `--rpc-host=0.0.0.0` and --monitoring-host=0.0.0.0` instructions to running with docker