### PR TITLE
Github Action to check broken links

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -1,0 +1,34 @@
+name: link-check
+
+on: 
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+jobs:
+  link-check:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./website
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install node.js 12
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+
+      - name: Install deps and build
+        run: |
+          npm install
+          yarn build
+
+      - name: Check links
+        uses: ruzickap/action-my-broken-link-checker@v1
+        with:
+          url: https://docs.prylabs.network/docs/
+          pages_path: ./website/build/
+          cmd_params: "--buffer-size=8192 --concurrency=10 --skip-tls-verification -e (#!)$"
+          run_timeout: 10


### PR DESCRIPTION
Basic link checker Github Action workflow.

It's set to ignore #! links used in the sidebar navigation.