### PR TITLE
Add Robots.txt to Disallow Old Docs Path

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -51,6 +51,11 @@ http {
             root   /usr/share/nginx/html;
         }
 
+        location = /robots.txt {
+            add_header Content-Type text/plain;
+            return 200 "User-agent: *\nDisallow: /docs/docs\n";
+        }
+
         # proxy the PHP scripts to Apache listening on 127.0.0.1:80
         #
         #location ~ \.php$ {


### PR DESCRIPTION
Search engines are indexing /docs/docs subpaths which lead to broken links. This PR adds a robots.txt entry to our nginx config to disallow such path from all user agents.