### PR TITLE
Add RPC Host and Monitoring Host to Docker Instructions

### DIFF
--- a/website/docs/install/lin/docker.md
+++ b/website/docs/install/lin/docker.md
@@ -65,7 +65,9 @@ To start your beacon node, issue the following command:
 ```text
 docker run -it -v $HOME/.eth2:/data -p 4000:4000 -p 13000:13000 -p 12000:12000/udp --name beacon-node \
   gcr.io/prysmaticlabs/prysm/beacon-chain:latest \
-  --datadir=/data
+  --datadir=/data \
+  --rpc-host=0.0.0.0 \
+  --monitoring-host=0.0.0.0
 ```
 
 This will sync up the beacon node with the latest head block in the network.

--- a/website/docs/install/mac/docker.md
+++ b/website/docs/install/mac/docker.md
@@ -68,7 +68,9 @@ To start your beacon node, issue the following command:
 docker run -it -v $HOME/.eth2:/data -p 4000:4000 -p 13000:13000 -p 12000:12000/udp --name beacon-node \
 
   gcr.io/prysmaticlabs/prysm/beacon-chain:latest \
-  --datadir=/data
+  --datadir=/data \
+  --rpc-host=0.0.0.0 \
+  --monitoring-host=0.0.0.0
 ```
 
 This will sync up the beacon node with the latest head block in the network.

--- a/website/docs/install/win/docker.md
+++ b/website/docs/install/win/docker.md
@@ -68,7 +68,7 @@ Below are instructions for initialising a beacon node and connecting to the publ
 3. To run the beacon node, issue the following command:
 
 ```text
-docker run -it -v %LOCALAPPDATA%\Eth2:/data -p 4000:4000 -p 13000:13000 -p 12000:12000/udp gcr.io/prysmaticlabs/prysm/beacon-chain:latest --datadir=/data
+docker run -it -v %LOCALAPPDATA%\Eth2:/data -p 4000:4000 -p 13000:13000 -p 12000:12000/udp gcr.io/prysmaticlabs/prysm/beacon-chain:latest --datadir=/data --rpc-host=0.0.0.0 --monitoring-host=0.0.0.0
 ```
 
 This will sync up the beacon node with the latest cannonical head block in the network. The Docker `-d` flag can be appended before the `-v` flag to launch the process in a detached terminal window.


### PR DESCRIPTION
Users running the beacon node with default docker parameters should be using --rpc-host=0.0.0.0 and --monitoring-host=0.0.0.0, this PR adds the following flags