### PR TITLE
Accounts V2 Documentation

### DIFF
--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -76,23 +76,9 @@ I deposited but it’s taking a long time to become active - how can I check if 
 
 Even after you deposit, it takes several hours to join the testnet as an active validator and can take even longer if there is a queue ahead of you. You can track your validator’s status on block explorers such as https://beaconcha.in and https://beacon.etherscan.io. Please be patient, as there is quite a wait for new validators to become active.
 
-#### How can I check on the status of my validator?
-
-Make sure your beacon node is synced and running, and run the command
-`./prysm.sh validator accounts status --keymanager={unencrypted, interop, keystore, wallet} --keymanageropts={$YOUR_PATH, $YOUR_PATH/keymanageropts.json} --beacon-rpc-provider=localhost:4000`.
-
-
 #### I made a correct deposit and my validator status is still UNKNOWN, what’s going on?
 
 There are a few possibilities. (1) your deposit has not yet been processed by beacon nodes. It takes a while for the beacon node to be able to process logs from the eth1 Goerli chain by design. If you have already waited a few hours and no luck, there is a chance that (2) your deposit did not verify (that is, you used some other method of creating the deposit than our recommended, standard way on prylabs.net), or (3) you never actually sent a deposit to the right contract address
-
-#### How can I check my validator public key?
-
-You can run the command `./prysm.sh validator accounts keys --keystore-path=$HOME/validator --password=YOURPASSWORD` to check your validator public keys currently within that keystore.
-
-I’m running my node and validator and they seem fine but my balance is going down, help!
-
-First of all, check your validator public key on https://beaconcha.in or https://beacon.etherscan.io to cross-reference that you are, indeed, losing funds as detailed by these block explorers. Note that block explorers may not always have the most up-to-date information. Also, check your node and validator for any errors (is the beacon node full of ERROR logs? is it off? Is the validator client down?). Finally, if everything seems perfect to you but you are still losing funds, please get in touch with us on our discord [here](https://discord.gg/CTYGPUJ).
 
 #### What is balance and what is effective balance?
 
@@ -101,7 +87,3 @@ Your validator balance is the actual amount of ETH you have from being a validat
 #### When do my validators get to propose a block?
 
 Validators receive new assignments approximately every 6.4 minutes. This period of time is known as an “epoch” and you may be assigned to propose a block several times in an epoch. Proposing a block, however, is rare, as there can only be one block proposer per slot and there are many validators in the network. Voting on blocks, that is, being assigned as an attester, is very common and you will be assigned to attest once per epoch if you are an active validator. You can see how many votes your validator has been assigned to create vs. how many blocks your validator has been assigned to propose by using a popular block explorer such as https://beaconcha.in and looking up your validator index or public key.
-
-#### How can I run multiple validator keys at the same time? Do I need to spin up multiple validator clients?
-
-A validator client looks for a keystore to read in multiple keys and use them for validating. As long as you created multiple accounts in the same keystore, you will be able to use a single validator client to run multiple keys. We’ve even been able to run 50,000 keys on a single validator!

--- a/website/docs/prysm-usage/parameters.md
+++ b/website/docs/prysm-usage/parameters.md
@@ -30,7 +30,7 @@ datadir: '/data'
 ```
 or for a validator like so:
 ```sh
-./prysm.sh validator --config-file=/path/to/file.yaml
+./prysm.sh validator --config-file=/path/to/file.yaml --enable-accounts-v2
 ```
 
 ### Windows
@@ -47,7 +47,7 @@ datadir: 'c:\prysm'
 ```
 or for a validator like so:
 ```sh
-.\prysm.bat validator --config-file=c:\path\to\file.yaml
+.\prysm.bat validator --config-file=c:\path\to\file.yaml --enable-accounts-v2
 ```
 
 It is possible to provide additional flags alongside the `.yaml` file, though if there is conflicts, the `.yaml` file will take priority. For example, if the flag `--datadir=/data2` is specified and `datadir: "/data1"` is in the `.yaml` file, Prysm would prioritise writing to `/data1`.

--- a/website/docs/prysm-usage/secure-grpc.md
+++ b/website/docs/prysm-usage/secure-grpc.md
@@ -23,16 +23,16 @@ To use secure gRPC with a beacon node:
 and to use secure gRPC with a validator:
 
 ```text
-./prysm.sh validator --tls-cert=server.pem
+./prysm.sh validator --tls-cert=server.pem --enable-accounts-v2
 ```
 
 Alternatively, a `ca.cert` certificate authority file can be passed to the validator to attempt a connection without requiring the server's certificate itself:
  
 ```text
-./prysm.sh validator --tls-cert=ca.cert
+./prysm.sh validator --tls-cert=ca.cert --enable-accounts-v2
 ```
 
-    This will generate an output like so:
+This will generate an output like so:
 
 ```text
 [2020-06-15 17:09:13]  INFO validator: Established secure gRPC connection
@@ -123,14 +123,14 @@ Alternatively, a `ca.cert` certificate authority file can be passed to the valid
 
 1. Use the certificates to launch the beacon node:
 
-```text
-./prysm.sh beacon-node --tls-cert=beacon.pem --tls-key=beacon.key
-```
+    ```text
+    ./prysm.sh beacon-node --tls-cert=beacon.pem --tls-key=beacon.key
+    ```
 
 2. As well as a validator:
 
     ```text
-    ./prysm.sh validator --tls-cert=ca.cert
+    ./prysm.sh validator --tls-cert=ca.cert --enable-accounts-v2
     ```
 
     This will generate an output like so: 

--- a/website/docs/prysm-usage/wallet-keymanager.md
+++ b/website/docs/prysm-usage/wallet-keymanager.md
@@ -4,7 +4,11 @@ title: Wallet keymanagers
 sidebar_label: Wallet keymanager
 ---
 
-A wallet keymanager is the recommended way of storing and accessing wallet keys on a local filesystem. The below guide outlines the configuration and operation of [ethdo](https://github.com/wealdtech/ethdo), a third-party software package that is used to perform several common tasks on Ethereum 2.0, including keystore functionality. It follows the Ethereum 2.0 specification and provides cross-client support (interoperability) as well as advanced features suitable for multi-node deployments.
+:::danger Deprecated
+This wallet keymanager is now deprecated and no longer the recommended way to manage accounts in Prysm. Read [wallet and accounts](http://localhost:3000/docs/wallet/introduction) for the latest information and usage.
+:::
+
+A wallet keymanager is a way of storing and accessing wallet keys on a local filesystem. The below guide outlines the configuration and operation of [ethdo](https://github.com/wealdtech/ethdo), a third-party software package that is used to perform several common tasks on Ethereum 2.0, including keystore functionality. It follows the Ethereum 2.0 specification and provides cross-client support (interoperability) as well as advanced features suitable for multi-node deployments.
 
   > **IMPORTANT NOTICE:** As Prysmatic Labs cannot endorse third party tools used to manage keys in a production environment, the guide on this page is no longer maintained and, if followed, there **is a risk that your deposit will experience issues**. It is highly recommended to compliment this guide with the latest `ethdo` installation and usage instructions found in [this guide on Github](https://github.com/wealdtech/ethdo/blob/master/docs/usage.md).
   

--- a/website/docs/wallet/deterministic.md
+++ b/website/docs/wallet/deterministic.md
@@ -4,3 +4,160 @@ title: Deterministic, HD wallet
 sidebar_label: HD wallet
 ---
 
+## Background
+
+An HD wallet provides the ability to create new validator private keys deterministically from a seed phrase, shown as an english mnemonic following the [BIP-39 standard](https://en.bitcoin.it/wiki/Seed_phrase) upon wallet creation. If you created a deposit using the official [Medalla testnet launchpad](https://medalla.launchpad.ethereum.org/) and want to run Prysm using it, see our dedicated instructions [here](http://docs.prylabs.network/docs/prysm-usage/medalla-testnet).
+
+Validator private keys are encrypted with the wallet's password using the [EIP-2335](https://eips.ethereum.org/EIPS/eip-2335) keystore.json standard for storing BLS12-381 private keys. This keystore.json file, along with its derivation path, comprises an **account** in an HD wallet.
+
+## Usage
+
+### Wallet creation
+
+To start using the HD wallet, you can create a new wallet using
+
+```bash
+./prysm.sh validator wallet-v2 create
+```
+
+:::info
+You'll need to set a **strong** password for your new HD wallet, containing at least 1 uppercase letter, 1 number, a special character, and be at least 8 characters long. Any unicode characters can be used for your wallet password.
+:::
+
+and selecting **HD** wallet when prompted during an interactive process. You can also create a wallet **non-interactively** by using the following command line flags, which are also viewable by typing `./prysm.sh validator wallet-v2 create --help`.
+
+| Flag          | Usage         |
+| ------------- |:-------------|
+| `--wallet-dir` | Path to a wallet directory (default: "$HOME/Eth2Validators/prysm-wallet-v2")
+| `--keymanager-kind`     | Type of wallet to create, either "direct", "derived, or "remote" (default "derived")
+| `--password-file`     | Path to a plain-text, password.txt file to lock your wallet
+
+Here's a full example on how to create an HD wallet at `$HOME/myhdwallet`
+
+```bash
+./prysm.sh validator wallet-v2 create --wallet-dir=$HOME/myhdwallet --keymanager-kind=derived --password-file=password.txt
+```
+
+### Wallet recovery
+
+You can fully recover an HD wallet along with all its accounts from a 24-word english mnemonic phrase generated during the wallet's creation process (which you should have stored offline). To recover your HD wallet in Prysm, you can run
+
+```bash
+./prysm.sh validator wallet-v2 recover
+```
+
+Output
+
+```text
+✔ Enter the wallet recovery phrase: layer write film stuff camp album strong ...
+Enter a wallet directory: /Users/johndoe/Library/Eth2Validators/.prysm-wallet-v2
+New wallet password: *********
+Confirm password: *********
+Enter how many accounts you would like to recover: 2
+[2020-07-27 11:54:16]  INFO accounts-v2: Successfully recovered HD wallet with 2 accounts. Please use accounts-v2 list to view details for your accounts. wallet-path=/Users/johndoe/Library/Eth2Validators/prysm-wallet-v2
+```
+
+:::info Recovering many accounts
+Your accounts are generated deterministically from your recovery phrase, so you had 100 validator accounts on the wallet you want to recover, you can easily do so in Prysm.
+:::
+
+| Flag          | Usage         |
+| ------------- |:-------------|
+| `--wallet-dir` | Path to a wallet directory (default: "$HOME/Eth2Validators/prysm-wallet-v2")
+| `--num-accounts` | Total number of accounts to recover from the wallet (default 1)
+
+### New validator account
+
+You can create a new validator account for your HD wallet using the following command
+
+```bash
+./prysm.sh validator accounts-v2 create
+```
+
+This command will generate both a withdrawal key and a validating key for eth2. Soon after, the command will complete and you will see an **important** piece of information you'll need to activate your eth2 validator.
+
+```go
+INFO accounts-v2: (wallet path) /Users/johndoe/Library/Eth2Validators/prysm-wallet-v2
+
+Copy + paste the deposit data below when using the eth1 deposit contract
+
+========================Deposit Data===============================
+
+0x2289511800000000000000000000000000000000000000000...
+
+===================================================================
+
+INFO hd-wallet: Successfully created new validator 
+account_name=personally-conscious-echidna
+```
+
+You can then copy the deposit data text and use it when sending 32ETH to the Validator Deposit Contract for eth2.
+
+You can also create a new validator account **non-interactively** by using the following command line flags, which are also viewable by typing `./prysm.sh validator accounts-v2 create --help`.
+
+| Flag          | Usage         |
+| ------------- |:-------------|
+| `--wallet-dir` | Path to a wallet directory (default: "$HOME/Eth2Validators/prysm-wallet-v2")
+| `--password-file` | Path to a plain-text, password.txt file to unlock your wallet
+| `--num-accounts` | Total number of accounts to generate (default: 1)
+
+Here's a full example on how to create a new validator account for your HD wallet stored at `$HOME/myhdwallet`.
+
+```bash
+./prysm.sh validator accounts-v2 create --wallet-dir=$HOME/myhdwallet --password-file=password.txt
+```
+
+### List validator accounts
+
+You can list all validator accounts in your HD wallet using the following command
+
+```bash
+./prysm.sh validator accounts-v2 list
+```
+
+Where you'll see the following output
+
+```bash
+INFO accounts-v2: (wallet path) /Users/johndoe/Library/Eth2Validators/prysm-wallet-v2
+
+Showing **1** validator account
+View the eth1 deposit transaction data for your accounts by running `validator accounts-v2 list --show-deposit-data
+
+personally-conscious-echidna
+[withdrawal public key] 0xa9c19b160cdc5c6dd74bf5a528d53b9a196ab8dda550e7e5858d84bf356952a310b826e269b9b462293f1c2812263161
+[validating public key] 0x971d780edfe98743f41cdcdba8521548fc343ffcd958e90968c4f1cc5a2e9b6ea11a984397c34c6cc13e9d4e8d14ce1e
+[created at] 16 minutes ago
+```
+
+You can view the `deposit_data` needed to send 32ETH to the eth2 deposit contract for your validator accounts by optionally passing in a `--show-deposit-data` flag as follows.
+
+```bash
+./prysm.sh validator accounts-v2 list --show-deposit-data
+```
+
+Where you'll see the following output
+
+```bash
+INFO accounts-v2: (wallet path) /Users/johndoe/Library/Eth2Validators/prysm-wallet-v2
+
+Showing **1** validator account
+
+personally-conscious-echidna
+[withdrawal public key] 0xa9c19b160cdc5c6dd74bf5a528d53b9a196ab8dda550e7e5858d84bf356952a310b826e269b9b462293f1c2812263161
+[validating public key] 0x971d780edfe98743f41cdcdba8521548fc343ffcd958e90968c4f1cc5a2e9b6ea11a984397c34c6cc13e9d4e8d14ce1e
+[created at] 16 minutes ago
+
+========================Deposit Data===============================
+
+0x2289511800000000000000000000000000000000000000000...
+
+===================================================================
+```
+
+You can also run the `accounts-v2 list` command **non-interactively** by using the following command line flags, which are also viewable by typing `./prysm.sh validator accounts-v2 list --help`.
+
+| Flag          | Usage         |
+| ------------- |:-------------|
+| `--wallet-dir` | Path to a wallet directory (default: "$HOME/Eth2Validators/prysm-wallet-v2")
+| `--show-deposit-data`     |  Display raw eth1 tx deposit data for validator accounts-v2 (default: false
+

--- a/website/docs/wallet/deterministic.md
+++ b/website/docs/wallet/deterministic.md
@@ -1,0 +1,6 @@
+---
+id: deterministic
+title: Deterministic, HD wallet 
+sidebar_label: HD wallet
+---
+

--- a/website/docs/wallet/introduction.md
+++ b/website/docs/wallet/introduction.md
@@ -1,0 +1,11 @@
+---
+id: introduction
+title: How to use the Prysm wallet for validator accounts
+sidebar_label: Introduction
+---
+
+This section explains everything about how to manage validator accounts using Prysm's built-in wallet, as well as setup instructions for different types of wallets including HD (hierarchical deterministic), non-HD, and remote signing wallets.
+
+:::tip Pro-Tip
+Prysm's validator accounts are extensible enough to allow for the most basic setup all the way to advanced production setups where security is paramount
+:::

--- a/website/docs/wallet/introduction.md
+++ b/website/docs/wallet/introduction.md
@@ -1,11 +1,73 @@
 ---
 id: introduction
-title: How to use the Prysm wallet for validator accounts
+title: Wallets and validator accounts
 sidebar_label: Introduction
 ---
 
-This section explains everything about how to manage validator accounts using Prysm's built-in wallet, as well as setup instructions for different types of wallets including HD (hierarchical deterministic), non-HD, and remote signing wallets.
+This section explains everything about how to manage validator accounts using Prysm's built-in wallet, as well as setup instructions for different types of wallets including HD (hierarchical deterministic), non-HD, and remote signing wallets. If you created a wallet using the official [Medalla testnet launchpad](https://medalla.launchpad.ethereum.org/) and want to run Prysm using it, see our dedicated instructions [here](http://docs.prylabs.network/docs/prysm-usage/medalla-testnet).
 
 :::tip Pro-Tip
 Prysm's validator accounts are extensible enough to allow for the most basic setup all the way to advanced production setups where security is paramount
 :::
+
+Out of the box, Prysm supports 3 basic kinds of wallets that encompass many different use-cases
+
+1. **HD wallet**: (Default) A common type of blockchain wallet which is generated from a english mnemonic, able to create new accounts deterministically
+2. **non-HD wallet**: A simple wallet in which accounts are password protected and validator keys are generated non-deterministically. This is the recommended approach if you want to import an account from the [Medalla testnet launchpad](https://medalla.launchpad.ethereum.org/) and you read dedicated instructions [here](http://docs.prylabs.network/docs/prysm-usage/medalla-testnet).
+3. **Remote signing wallet**: An advanced kind of wallet in which validator keys and signing requests are processed by a remote server via gRPC (view our remote server [reference implementation](https://github.com/prysmaticlabs/remote-signer))
+
+At the core of Prysm's validator accounts lies the notion of a validator private key, which is stored in a password-protected, keystore.json file. Prysm supports the ability to manage many validator accounts, making it easy to import and export them as well as easily list all the account info in your wallet. Prysm is compliant with the [EIP-2335](https://eips.ethereum.org/EIPS/eip-2335) standards for storing eth2 validator private keys, making it possible to move keys between different eth2 client implementations.
+
+## HD wallets
+
+By default, a Prysm validator client encourages use of an **HD wallet**, which you can recover from a 24-word, simple english sentence should you lose access to it, such as:
+
+```text
+glue hawk service repeat album stable arctic piece kiss arrive viable labor connect film deer trap brain fashion duck omit beach ten slot goat
+```
+
+HD wallets are password protected, and allow for easy creation of as many validator account as you wish.
+
+[Create and use an HD wallet](https://docs.prylabs.network/docs/wallet/deterministic)
+
+## Non-HD wallets
+
+Prysm also supports a non-deterministic wallet, which is a very simple kind of wallet storing password-protected validating keys on disk, with passwords stored in a separate directory for ease of use. This type of wallet makes it very easy to import and export accounts, useful for certain cloud deployments in which you don't want to store your eth2 withdrawal keys on-disk. This wallet is also the recommended approach if you generated a validator deposit using the [Medalla testnet launchpad](https://medalla.launchpad.ethereum.org/).
+
+```text
+wallet-directory/
+  perfectly-intense-mosquito/
+    keystore.json
+passwords-directory/
+  perfectly-intense-mosquito.pass
+```
+
+[Create and use a non-HD wallet](https://docs.prylabs.network/docs/wallet/nondeterministic)
+
+## Remote signing wallet
+
+Some advanced users may wish to run a remote-signer server, which handles the retrieval of keys and signing of eth2 requests. A Prysm validator client can then connect securely via [gRPC](https://grpc.io) to the remote server and perform its validating duties by relying on the server for the information it needs. Most advanced cloud deployments should likely use this approach, as it is the most customizable.
+
+To be compliant with a Prysm remote signing wallet, your remote signing server needs to implement the gRPC API specified in Prysm [here](https://github.com/prysmaticlabs/prysm/blob/7fff4ec41165e6581dda352b362d77fc6ca2710d/proto/validator/accounts/v2/keymanager.proto#L12).
+
+```go
+service RemoteSigner {
+    // ListPublicKeysResponse managed by a remote signer.
+    rpc ListValidatingPublicKeys(google.protobuf.Empty) returns (ListPublicKeysResponse) {
+        option (google.api.http) = {
+            get: "/accounts/v2/remote/accounts"
+        };
+    }
+
+    // Sign a remote request via gRPC.
+    rpc Sign(SignRequest) returns (SignResponse) {
+        option (google.api.http) = {
+            post: "/accounts/v2/remote/sign"
+        };
+    }
+}
+```
+
+We have also a created a reference remote signer implementation, maintained as an open source, Apache 2 project on Github [here](https://github.com/prysmaticlabs/remote-signer) as a starting point.
+
+[Create and use a remote signing wallet](https://docs.prylabs.network/docs/wallet/remote)

--- a/website/docs/wallet/introduction.md
+++ b/website/docs/wallet/introduction.md
@@ -18,6 +18,12 @@ Out of the box, Prysm supports 3 basic kinds of wallets that encompass many diff
 
 At the core of Prysm's validator accounts lies the notion of a validator private key, which is stored in a password-protected, keystore.json file. Prysm supports the ability to manage many validator accounts, making it easy to import and export them as well as easily list all the account info in your wallet. Prysm is compliant with the [EIP-2335](https://eips.ethereum.org/EIPS/eip-2335) standards for storing eth2 validator private keys, making it possible to move keys between different eth2 client implementations.
 
+To run this new version of Prysm's account management, you will need to run your validator client with the `--enable-accounts-v2` flag. For example
+
+```text
+./prysm.sh validator --enable-accounts-v2
+```
+
 ## HD wallets
 
 By default, a Prysm validator client encourages use of an **HD wallet**, which you can recover from a 24-word, simple english sentence should you lose access to it, such as:

--- a/website/docs/wallet/nondeterministic.md
+++ b/website/docs/wallet/nondeterministic.md
@@ -1,0 +1,195 @@
+---
+id: nondeterministic
+title: Non-deterministic wallet 
+sidebar_label: Non-HD wallet
+---
+
+## Background
+
+A Non-HD wallet provides the ability to create simple, encrypted validators accounts stored directly-on disk. Validator private keys are generated non-deterministically, meaning there is **no seed phrase** (mnemonic) which can be used to recover an entire wallet. 
+
+:::tip Pro-Tip
+We always recommend using an [HD wallet](http://docs.prylabs.network/docs/wallet/deterministic), as it provides the greatest flexibility, security, and compatibility with blockchain standards. Using an HD wallet allows you to recover your wallet with all your precious accounts easily from a mnemonic phrase you can store offline should anything happen to your computer.
+:::
+
+Validator private keys are encrypted with a password using the [EIP-2335](https://eips.ethereum.org/EIPS/eip-2335) keystore.json standard for storing BLS12-381 private keys. This keystore.json file, along with a `deposit_data` transaction file and a timestamp file comprise an **account** in a non-HD wallet.
+
+Accounts are stored in the wallet's directory using human-readable names such as `personally-conscious-echidna`.
+
+```
+wallet-dir/
+	personally-conscious-echidna/
+		keystore.json
+		deposit_transaction.rlp
+ 		created_at.txt
+	shy-extroverted-robin/
+		keystore.json
+		deposit_transaction.rlp
+ 		created_at.txt
+```
+
+For ease of use, passwords for each account are also stored on disk at a separate, user-selected directory. This makes it easy to run the non-HD wallet without needing to manually unlock every account each time.
+
+```
+wallet-passwords/
+ personally-conscious-echidna.pass
+ shy-extroverted-robin.pass
+```
+
+Validator deposit credentials are also stored under the account's path in the wallet directory, containing a `deposit_transaction.rlp` with raw bytes eth1 transaction data ready to be used to submit a 32ETH deposit to the eth2 deposit contract for the corresponding validator account. 
+
+##  Usage
+
+### Wallet creation
+
+A non-HD wallet is the most basic sort of wallet, storing all information on-disk. This approach makes it trivial to import, export and list all associated accounts within the wallet. To start using the non-HD wallet, you can create a new wallet using
+
+```bash
+./prysm.sh validator wallet-v2 create
+```
+
+and selecting **non-HD** wallet when prompted during an interactive process. You can also create a wallet **non-interactive** by using the following command line flags, which are also viewable by typing `./prysm.sh validator wallet-v2 create --help.
+
+| Flag          | Usage         |
+| ------------- |:-------------|
+| `--wallet-dir` | Path to a wallet directory (default: "$HOME/Eth2Validators/prysm-wallet-v2")
+| `--passwords-dir`     | Path to a directory where account passwords will be stored (default: "$HOME/Eth2Validators/prysm-wallet-passwords")
+| `--keymanager-kind`     | Type of wallet to create, either "direct", "derived, or "remote" (default "derived")
+
+Here's a full example on how to create a non-HD wallet at `/tmp/mynonhdwallet` with account passwords stored at `/tmp/myaccountpasswords`.
+
+```bash
+./prysm.sh validator wallet-v2 create --wallet-dir=/tmp/nonhdwallet --passwords-dir=/tmp/myaccountpasswords --keymanager-kind=direct
+```
+
+### New validator account
+
+You can create a new validator account for your non-HD wallet using the following command
+
+```bash
+./prysm.sh validator accounts-v2 create
+```
+
+:::info
+You'll need to set a **strong** password for your new validator account, containing at least 1 uppercase letter, 1 number, a special character, and be at least 8 characters long. Any unicode characters can be used for your account passwords.
+:::
+
+You'll be guided through an interactive process where you'll need to pick a new password for your validator. Soon after, the command will complete and you will see two **important** pieces of information you'll need for your validator.
+
+```go
+INFO accounts-v2: (wallet path) /Users/johndoe/Library/Eth2Validators/prysm-wallet-v2
+INFO accounts-v2: (account passwords path) /Users/johndoe/Library/Eth2Validators/prysm-wallet-v2-passwords
+New account password: *********█
+Confirm password: *********█
+
+INFO non-hd-wallet: Write down the private key, as it is your unique withdrawal private key for eth2
+
+==========================Withdrawal Key===========================
+
+0x14d0acc3eb479b5a7da91a5cb8c6a7454bed05322e189abea...
+
+===================================================================
+
+Copy + paste the deposit data below when using the eth1 deposit contract
+
+========================Deposit Data===============================
+
+0x2289511800000000000000000000000000000000000000000...
+
+===================================================================
+
+INFO non-hd-wallet: Successfully created new validator 
+account_name=personally-conscious-echidna
+```
+
+Copy your **withdrawal key** somewhere safe and offline, as it is your only means of withdrawing your validator rewards from participating in eth2. You can then copy the deposit data text and use it when sending 32ETH to the Validator Deposit Contract for eth2.
+
+You can also create a new validator account **non-interactively** by using the following command line flags, which are also viewable by typing `./prysm.sh validator accounts-v2 create --help.
+
+| Flag          | Usage         |
+| ------------- |:-------------|
+| `--wallet-dir` | Path to a wallet directory (default: "$HOME/Eth2Validators/prysm-wallet-v2")
+| `--passwords-dir`     | Path to a directory where account passwords will be stored (default: "$HOME/Eth2Validators/prysm-wallet-passwords")
+| `--password-file`     | Path to plaintext file containing your desired new account password
+
+
+Here's a full example on how to create a new validator account for your non-HD wallet stored at `/tmp/mynonhdwallet` with account passwords stored at `/tmp/myaccountpasswords`.
+
+```bash
+./prysm.sh validator accounts-v2 create --wallet-dir=/tmp/nonhdwallet --passwords-dir=/tmp/myaccountpasswords --password-file=password.txt
+```
+
+Where you provide a plain-text `password.txt` containing your account password.
+
+### List validator accounts
+
+You can list all validator accounts in your non-HD wallet using the following command
+
+```bash
+./prysm.sh validator accounts-v2 list
+```
+
+Where you'll see the following output
+
+```bash
+INFO accounts-v2: (wallet path) /Users/johndoe/Library/Eth2Validators/prysm-wallet-v2
+INFO accounts-v2: (account passwords path) /Users/johndoe/Library/Eth2Validators/prysm-wallet-passwords
+
+Showing **1** validator account
+View the eth1 deposit transaction data for your accounts by running `validator accounts-v2 list --show-deposit-data
+
+personally-conscious-echidna
+[public key] 0x971d780edfe98743f41cdcdba8521548fc343ffcd958e90968c4f1cc5a2e9b6ea11a984397c34c6cc13e9d4e8d14ce1e
+[created at] 16 minutes ago
+```
+
+You can view the `deposit_data` needed to send 32ETH to the eth2 deposit contract for your validator accounts by optionally passing in a `--show-deposit-data` flag as follows.
+
+```bash
+./prysm.sh validator accounts-v2 list --show-deposit-data
+```
+
+Where you'll see the following output
+
+```bash
+INFO accounts-v2: (wallet path) /Users/johndoe/Library/Eth2Validators/prysm-wallet-v2
+INFO accounts-v2: (account passwords path) /Users/johndoe/Library/Eth2Validators/prysm-wallet-passwords
+
+Showing **1** validator account
+
+personally-conscious-echidna
+[public key] 0x971d780edfe98743f41cdcdba8521548fc343ffcd958e90968c4f1cc5a2e9b6ea11a984397c34c6cc13e9d4e8d14ce1e
+[created at] 16 minutes ago
+
+========================Deposit Data===============================
+
+0x2289511800000000000000000000000000000000000000000...
+
+===================================================================
+```
+
+You can also run the `accounts-v2 list` command **non-interactively** by using the following command line flags, which are also viewable by typing `./prysm.sh validator accounts-v2 list --help.
+
+| Flag          | Usage         |
+| ------------- |:-------------|
+| `--wallet-dir` | Path to a wallet directory (default: "$HOME/Eth2Validators/prysm-wallet-v2")
+| `--passwords-dir`     | Path to a directory where account passwords will be stored (default: "$HOME/Eth2Validators/prysm-wallet-passwords")
+| `--show-deposit-data`     |  Display raw eth1 tx deposit data for validator accounts-v2 (default: false
+
+### Import validator accounts
+
+You can import a validator account from a zip file into your non-HD wallet using the following command
+
+```bash
+./prysm.sh validator accounts-v2 import
+```
+
+TODO: Work-in-progress
+
+### Export validator accounts
+
+You can export validator accounts from your non-HD wallet into their own zip file using the following command
+
+```bash
+./prysm.sh validator accounts-v2 export
+```

--- a/website/docs/wallet/nondeterministic.md
+++ b/website/docs/wallet/nondeterministic.md
@@ -6,13 +6,13 @@ sidebar_label: Non-HD wallet
 
 ## Background
 
-A Non-HD wallet provides the ability to create simple, encrypted validators accounts stored directly-on disk. Validator private keys are generated non-deterministically, meaning there is **no seed phrase** (mnemonic) which can be used to recover an entire wallet. 
+A Non-HD wallet provides the ability to create simple, encrypted validators accounts stored directly-on disk. Validator private keys are generated non-deterministically, meaning there is **no seed phrase** (mnemonic) which can be used to recover an entire wallet. If you created a deposit using the official [Medalla testnet launchpad](https://medalla.launchpad.ethereum.org/) and want to run Prysm using it, see our dedicated instructions [here](http://docs.prylabs.network/docs/prysm-usage/medalla-testnet).
 
 :::tip Pro-Tip
-We always recommend using an [HD wallet](http://docs.prylabs.network/docs/wallet/deterministic), as it provides the greatest flexibility, security, and compatibility with blockchain standards. Using an HD wallet allows you to recover your wallet with all your precious accounts easily from a mnemonic phrase you can store offline should anything happen to your computer.
+In general, we recommend using an [HD wallet](http://docs.prylabs.network/docs/wallet/deterministic), as it provides the greatest flexibility, security, and compatibility with blockchain standards. Using an HD wallet allows you to recover your wallet with all your precious accounts easily from a mnemonic phrase you can store offline should anything happen to your computer.
 :::
 
-Validator private keys are encrypted with a password using the [EIP-2335](https://eips.ethereum.org/EIPS/eip-2335) keystore.json standard for storing BLS12-381 private keys. This keystore.json file, along with a `deposit_data` transaction file and a timestamp file comprise an **account** in a non-HD wallet.
+Validator private keys are encrypted with a password using the [EIP-2335](https://eips.ethereum.org/EIPS/eip-2335) keystore.json standard for storing BLS12-381 private keys. This keystore.json file, along with a human-readable name, comprises an **account** in a non-HD wallet.
 
 Accounts are stored in the wallet's directory using human-readable names such as `personally-conscious-echidna`.
 
@@ -20,11 +20,9 @@ Accounts are stored in the wallet's directory using human-readable names such as
 wallet-dir/
 	personally-conscious-echidna/
 		keystore.json
-		deposit_transaction.rlp
  		created_at.txt
 	shy-extroverted-robin/
 		keystore.json
-		deposit_transaction.rlp
  		created_at.txt
 ```
 
@@ -32,13 +30,13 @@ For ease of use, passwords for each account are also stored on disk at a separat
 
 ```
 wallet-passwords/
- personally-conscious-echidna.pass
- shy-extroverted-robin.pass
+	personally-conscious-echidna.pass
+	shy-extroverted-robin.pass
 ```
 
-Validator deposit credentials are also stored under the account's path in the wallet directory, containing a `deposit_transaction.rlp` with raw bytes eth1 transaction data ready to be used to submit a 32ETH deposit to the eth2 deposit contract for the corresponding validator account. 
+Validator deposit credentials are also stored under the account's path in the wallet directory, containing a `deposit_transaction.rlp` with raw bytes eth1 transaction data ready to be used to submit a 32ETH deposit to the eth2 deposit contract for the corresponding validator account.
 
-##  Usage
+## Usage
 
 ### Wallet creation
 
@@ -56,10 +54,10 @@ and selecting **non-HD** wallet when prompted during an interactive process. You
 | `--passwords-dir`     | Path to a directory where account passwords will be stored (default: "$HOME/Eth2Validators/prysm-wallet-passwords")
 | `--keymanager-kind`     | Type of wallet to create, either "direct", "derived, or "remote" (default "derived")
 
-Here's a full example on how to create a non-HD wallet at `/tmp/mynonhdwallet` with account passwords stored at `/tmp/myaccountpasswords`.
+Here's a full example on how to create a non-HD wallet at `$HOME/mynonhdwallet` with account passwords stored at `$HOME/myaccountpasswords`.
 
 ```bash
-./prysm.sh validator wallet-v2 create --wallet-dir=/tmp/nonhdwallet --passwords-dir=/tmp/myaccountpasswords --keymanager-kind=direct
+./prysm.sh validator wallet-v2 create --wallet-dir=$HOME/nonhdwallet --passwords-dir=$HOME/myaccountpasswords --keymanager-kind=direct
 ```
 
 ### New validator account
@@ -98,7 +96,7 @@ Copy + paste the deposit data below when using the eth1 deposit contract
 
 ===================================================================
 
-INFO non-hd-wallet: Successfully created new validator 
+INFO non-hd-wallet: Successfully created new validator account
 account_name=personally-conscious-echidna
 ```
 
@@ -110,13 +108,13 @@ You can also create a new validator account **non-interactively** by using the f
 | ------------- |:-------------|
 | `--wallet-dir` | Path to a wallet directory (default: "$HOME/Eth2Validators/prysm-wallet-v2")
 | `--passwords-dir`     | Path to a directory where account passwords will be stored (default: "$HOME/Eth2Validators/prysm-wallet-passwords")
-| `--password-file`     | Path to plaintext file containing your desired new account password
+| `--password-file`     | Path to a plain-text, password.txt file containing your desired new account password
 
 
-Here's a full example on how to create a new validator account for your non-HD wallet stored at `/tmp/mynonhdwallet` with account passwords stored at `/tmp/myaccountpasswords`.
+Here's a full example on how to create a new validator account for your non-HD wallet stored at `$HOME/mynonhdwallet` with account passwords stored at `$HOME/myaccountpasswords`.
 
 ```bash
-./prysm.sh validator accounts-v2 create --wallet-dir=/tmp/nonhdwallet --passwords-dir=/tmp/myaccountpasswords --password-file=password.txt
+./prysm.sh validator accounts-v2 create --wallet-dir=$HOME/nonhdwallet --passwords-dir=$HOME/myaccountpasswords --password-file=password.txt
 ```
 
 Where you provide a plain-text `password.txt` containing your account password.
@@ -158,7 +156,7 @@ INFO accounts-v2: (account passwords path) /Users/johndoe/Library/Eth2Validators
 Showing **1** validator account
 
 personally-conscious-echidna
-[public key] 0x971d780edfe98743f41cdcdba8521548fc343ffcd958e90968c4f1cc5a2e9b6ea11a984397c34c6cc13e9d4e8d14ce1e
+[validating public key] 0x971d780edfe98743f41cdcdba8521548fc343ffcd958e90968c4f1cc5a2e9b6ea11a984397c34c6cc13e9d4e8d14ce1e
 [created at] 16 minutes ago
 
 ========================Deposit Data===============================
@@ -193,3 +191,5 @@ You can export validator accounts from your non-HD wallet into their own zip fil
 ```bash
 ./prysm.sh validator accounts-v2 export
 ```
+
+TODO: Work-in-progress

--- a/website/docs/wallet/remote.md
+++ b/website/docs/wallet/remote.md
@@ -1,37 +1,48 @@
 ---
 id: remote
-title: Remote signer wallet
-sidebar_label: Remote signer wallet
+title: Remote signing wallet
+sidebar_label: Remote signing wallet
 ---
 
-Package remote defines an implementation of an on-disk, EIP-2335 keystore.json
-approach towards defining validator accounts in Prysm. A validating private key is
-encrypted using a passphrase and its resulting encrypted file is stored as a
-keystore.json file under a unique, human-readable, account namespace. This direct keymanager approach
-relies on storing account information on-disk, making it trivial to import, export and
-list all associated accounts for a user.
+## Background
 
-Package remote defines a keymanager implementation which connects to a remote signer
-server via gRPC. The connection is established via TLS using supplied paths to
-certificates and key files and allows for submitting remote signing requests for
-eth2 data structures as well as retrieving the available signing public keys from
-the remote server.
+A **remote signing wallet** provides the ability to connect to a remote server to retrieve validating public keys and process eth2 signing requests via a secure [gRPC](https://grpc.io) connection. You must supply valid TLS certificates for establishing the secure connection to your server. We have created a reference implementation of a remote signer server, maintained as an open source, Apache 2 project on Github [here](https://github.com/prysmaticlabs/remote-signer) as a starting point
 
-Remote sign requests are defined by the following protobuf schema:
+To be compliant with a Prysm remote signing wallet, your remote signing server needs to implement the gRPC API specified in Prysm [here](https://github.com/prysmaticlabs/prysm/blob/7fff4ec41165e6581dda352b362d77fc6ca2710d/proto/validator/accounts/v2/keymanager.proto#L12).
 
-```js
+```go
+service RemoteSigner {
+    // ListPublicKeysResponse managed by a remote signer.
+    rpc ListValidatingPublicKeys(google.protobuf.Empty) returns (ListPublicKeysResponse) {
+        option (google.api.http) = {
+            get: "/accounts/v2/remote/accounts"
+        };
+    }
+
+    // Sign a remote request via gRPC.
+    rpc Sign(SignRequest) returns (SignResponse) {
+        option (google.api.http) = {
+            post: "/accounts/v2/remote/sign"
+        };
+    }
+}
+```
+
+Remote sign requests are defined by the following protobuf schema
+
+```go
 // SignRequest is a message type used by a keymanager
 // as part of Prysm's accounts implementation.
 message SignRequest {
-	 // 48 byte public key corresponding to an associated private key
-	 // being requested to sign data.
-	 bytes public_key = 1;
+  // 48 byte public key corresponding to an associated private key
+  // being requested to sign data.
+  bytes public_key = 1;
 
-	 // Raw bytes signing root the client is requesting to sign. The client is
- // expected to determine these raw bytes from the appropriate BLS
-	 // signing domain as well as the signing root of the data structure
- // the bytes represent.
-	 bytes signing_root = 2;
+  // Raw bytes signing root the client is requesting to sign. The client is
+  // expected to determine these raw bytes from the appropriate BLS
+  // signing domain as well as the signing root of the data structure
+  // the bytes represent.
+  bytes signing_root = 2;
 }
 ```
 
@@ -39,30 +50,102 @@ Remote signing responses will contain a BLS12-381 signature along with the
 status of the signing response from the remote server, signifying the
 request either failed, was denied, or completed successfully.
 
-```js
+```go
 message SignResponse {
-	 enum Status {
-			 UNKNOWN = 0;
-			 SUCCEEDED = 1;
-			 DENIED = 2;
-			 FAILED = 3;
-	 }
-
-	 // BLS12-381 signature for the data specified in the request.
-	 bytes signature = 1;
+  enum Status {
+    UNKNOWN = 0;
+    SUCCEEDED = 1;
+    DENIED = 2;
+    FAILED = 3;
+  }
+  // BLS12-381 signature for the data specified in the request.
+  bytes signature = 1;
 }
 ```
 
-The remote keymanager can be customized via a keymanageropts.json file
-which requires the following schema:
+A Prysm validator client can then connect securely via [gRPC](https://grpc.io) to the remote server and perform its validating duties by relying on the server for the information it needs. Most advanced cloud deployments should likely use this approach, as it is the most customizable.
 
-```js
-{
- "remote_address": "remoteserver.com:4000", // Remote gRPC server address.
- "remote_cert": {
-	 "crt_path": "/home/eth2/certs/client.crt", // Client certificate path.
-	 "ca_crt_path": "/home/eth2/certs/ca.crt",  // Certificate authority cert path.
-	 "key_path": "/home/eth2/certs/client.key", // Client key path.
- }
-}
+## Usage
+
+### Wallet creation
+
+To create a new remote signing-capable wallet, you will need to prepare TLS certificates to connect securely to your remote gRPC server. Then, you can run
+
+```bash
+./prysm.sh validator wallet-v2 create
 ```
+
+:::info
+You will need a TLS client cert, client key, and a Certificate Authority (CA) cert to establish a secure gRPC connection
+:::
+
+and selecting **Remote** wallet when prompted during an interactive process. You can also create a wallet **non-interactively** by using the following command line flags, which are also viewable by typing `./prysm.sh validator wallet-v2 create --help`.
+
+| Flag          | Usage         |
+| ------------- |:-------------|
+| `--wallet-dir` | Path to a wallet directory (default: "$HOME/Eth2Validators/prysm-wallet-v2")
+| `--keymanager-kind`     | Type of wallet to create, either "direct", "derived, or "remote" (default "derived")
+| `--password-file`     | Path to a plain-text, password.txt file to lock your wallet
+
+### Wallet edit configuration
+
+To edit your existing remote wallet configuration, such as for changing the path of your TLS certs or remote address, you can run
+
+```bash
+./prysm.sh validator wallet-v2 edit-config
+```
+
+### List validator accounts
+
+You can list all validator accounts in your non-HD wallet using the following command
+
+```bash
+./prysm.sh validator accounts-v2 list
+```
+
+Where you'll see the following output
+
+```bash
+INFO accounts-v2: (wallet path) /Users/johndoe/Library/Eth2Validators/prysm-wallet-v2
+INFO accounts-v2: (account passwords path) /Users/johndoe/Library/Eth2Validators/prysm-wallet-passwords
+
+Showing **1** validator account
+View the eth1 deposit transaction data for your accounts by running `validator accounts-v2 list --show-deposit-data
+
+personally-conscious-echidna
+[public key] 0x971d780edfe98743f41cdcdba8521548fc343ffcd958e90968c4f1cc5a2e9b6ea11a984397c34c6cc13e9d4e8d14ce1e
+[created at] 16 minutes ago
+```
+
+You can view the `deposit_data` needed to send 32ETH to the eth2 deposit contract for your validator accounts by optionally passing in a `--show-deposit-data` flag as follows.
+
+```bash
+./prysm.sh validator accounts-v2 list --show-deposit-data
+```
+
+Where you'll see the following output
+
+```bash
+INFO accounts-v2: (wallet path) /Users/johndoe/Library/Eth2Validators/prysm-wallet-v2
+INFO accounts-v2: (account passwords path) /Users/johndoe/Library/Eth2Validators/prysm-wallet-passwords
+
+Showing **1** validator account
+
+personally-conscious-echidna
+[validating public key] 0x971d780edfe98743f41cdcdba8521548fc343ffcd958e90968c4f1cc5a2e9b6ea11a984397c34c6cc13e9d4e8d14ce1e
+[created at] 16 minutes ago
+
+========================Deposit Data===============================
+
+0x2289511800000000000000000000000000000000000000000...
+
+===================================================================
+```
+
+You can also run the `accounts-v2 list` command **non-interactively** by using the following command line flags, which are also viewable by typing `./prysm.sh validator accounts-v2 list --help.
+
+| Flag          | Usage         |
+| ------------- |:-------------|
+| `--wallet-dir` | Path to a wallet directory (default: "$HOME/Eth2Validators/prysm-wallet-v2")
+| `--passwords-dir`     | Path to a directory where account passwords will be stored (default: "$HOME/Eth2Validators/prysm-wallet-passwords")
+| `--show-deposit-data`     |  Display raw eth1 tx deposit data for validator accounts-v2 (default: false

--- a/website/docs/wallet/remote.md
+++ b/website/docs/wallet/remote.md
@@ -1,0 +1,68 @@
+---
+id: remote
+title: Remote signer wallet
+sidebar_label: Remote signer wallet
+---
+
+Package remote defines an implementation of an on-disk, EIP-2335 keystore.json
+approach towards defining validator accounts in Prysm. A validating private key is
+encrypted using a passphrase and its resulting encrypted file is stored as a
+keystore.json file under a unique, human-readable, account namespace. This direct keymanager approach
+relies on storing account information on-disk, making it trivial to import, export and
+list all associated accounts for a user.
+
+Package remote defines a keymanager implementation which connects to a remote signer
+server via gRPC. The connection is established via TLS using supplied paths to
+certificates and key files and allows for submitting remote signing requests for
+eth2 data structures as well as retrieving the available signing public keys from
+the remote server.
+
+Remote sign requests are defined by the following protobuf schema:
+
+```js
+// SignRequest is a message type used by a keymanager
+// as part of Prysm's accounts implementation.
+message SignRequest {
+	 // 48 byte public key corresponding to an associated private key
+	 // being requested to sign data.
+	 bytes public_key = 1;
+
+	 // Raw bytes signing root the client is requesting to sign. The client is
+ // expected to determine these raw bytes from the appropriate BLS
+	 // signing domain as well as the signing root of the data structure
+ // the bytes represent.
+	 bytes signing_root = 2;
+}
+```
+
+Remote signing responses will contain a BLS12-381 signature along with the
+status of the signing response from the remote server, signifying the
+request either failed, was denied, or completed successfully.
+
+```js
+message SignResponse {
+	 enum Status {
+			 UNKNOWN = 0;
+			 SUCCEEDED = 1;
+			 DENIED = 2;
+			 FAILED = 3;
+	 }
+
+	 // BLS12-381 signature for the data specified in the request.
+	 bytes signature = 1;
+}
+```
+
+The remote keymanager can be customized via a keymanageropts.json file
+which requires the following schema:
+
+```js
+{
+ "remote_address": "remoteserver.com:4000", // Remote gRPC server address.
+ "remote_cert": {
+	 "crt_path": "/home/eth2/certs/client.crt", // Client certificate path.
+	 "ca_crt_path": "/home/eth2/certs/ca.crt",  // Certificate authority cert path.
+	 "key_path": "/home/eth2/certs/client.key", // Client key path.
+ }
+}
+```

--- a/website/docs/wallet/remote.md
+++ b/website/docs/wallet/remote.md
@@ -106,43 +106,24 @@ You can list all validator accounts in your non-HD wallet using the following co
 Where you'll see the following output
 
 ```bash
-INFO accounts-v2: (wallet path) /Users/johndoe/Library/Eth2Validators/prysm-wallet-v2
-INFO accounts-v2: (account passwords path) /Users/johndoe/Library/Eth2Validators/prysm-wallet-passwords
+[2020-07-27 14:30:13]  INFO accounts-v2: (wallet path) /Users/johndoe/Library/Eth2Validators/prysm-wallet-v2
+(keymanager kind) remote signer
+(configuration file path) /Users/johndoe/Library/Eth2Validators/prysm-wallet-v2/remote/keymanageropts.json
 
-Showing **1** validator account
-View the eth1 deposit transaction data for your accounts by running `validator accounts-v2 list --show-deposit-data
-
-personally-conscious-echidna
-[public key] 0x971d780edfe98743f41cdcdba8521548fc343ffcd958e90968c4f1cc5a2e9b6ea11a984397c34c6cc13e9d4e8d14ce1e
-[created at] 16 minutes ago
-```
-
-You can view the `deposit_data` needed to send 32ETH to the eth2 deposit contract for your validator accounts by optionally passing in a `--show-deposit-data` flag as follows.
-
-```bash
-./prysm.sh validator accounts-v2 list --show-deposit-data
-```
-
-Where you'll see the following output
-
-```bash
-INFO accounts-v2: (wallet path) /Users/johndoe/Library/Eth2Validators/prysm-wallet-v2
-INFO accounts-v2: (account passwords path) /Users/johndoe/Library/Eth2Validators/prysm-wallet-passwords
+Configuration options
+Remote gRPC address: localhost:4000
+Client cert path: /path/to/example-client.crt
+Client key path: /path/to/example.client.key
+CA cert path: /path/to/ca.crt
 
 Showing **1** validator account
 
 personally-conscious-echidna
 [validating public key] 0x971d780edfe98743f41cdcdba8521548fc343ffcd958e90968c4f1cc5a2e9b6ea11a984397c34c6cc13e9d4e8d14ce1e
 [created at] 16 minutes ago
-
-========================Deposit Data===============================
-
-0x2289511800000000000000000000000000000000000000000...
-
-===================================================================
 ```
 
-You can also run the `accounts-v2 list` command **non-interactively** by using the following command line flags, which are also viewable by typing `./prysm.sh validator accounts-v2 list --help.
+You can view all available options to run the `list` command by typing `./prysm.sh validator accounts-v2 list --help.
 
 | Flag          | Usage         |
 | ------------- |:-------------|

--- a/website/docs/wallet/remote.md
+++ b/website/docs/wallet/remote.md
@@ -85,15 +85,28 @@ and selecting **Remote** wallet when prompted during an interactive process. You
 | ------------- |:-------------|
 | `--wallet-dir` | Path to a wallet directory (default: "$HOME/Eth2Validators/prysm-wallet-v2")
 | `--keymanager-kind`     | Type of wallet to create, either "direct", "derived, or "remote" (default "derived")
-| `--password-file`     | Path to a plain-text, password.txt file to lock your wallet
+| `--grpc-remote-address`     | Host:port of a gRPC server for the remote signer server
+| `--remote-signer-crt-path`     | /path/to/client.crt for establishing a secure, TLS gRPC connection to a remote signer server
+| `--remote-signer-key-path`     | /path/to/client.key for establishing a secure, TLS gRPC connection to a remote signer server
+| `--remote-signer-ca-crt-path`     | /path/to/ca.crt for establishing a secure, TLS gRPC connection to a remote signer server
 
 ### Wallet edit configuration
 
-To edit your existing remote wallet configuration, such as for changing the path of your TLS certs or remote address, you can run
+To edit your existing remote wallet configuration, such as changing the path of your TLS certs or remote address, you can run
 
 ```bash
 ./prysm.sh validator wallet-v2 edit-config
 ```
+
+You can also edit your wallet configuration **non-interactively** by using the following command line flags, which are also viewable by typing `./prysm.sh validator wallet-v2 create --help`.
+
+| Flag          | Usage         |
+| ------------- |:-------------|
+| `--wallet-dir` | Path to a wallet directory (default: "$HOME/Eth2Validators/prysm-wallet-v2")
+| `--grpc-remote-address`     | Host:port of a gRPC server for the remote signer server
+| `--remote-signer-crt-path`     | /path/to/client.crt for establishing a secure, TLS gRPC connection to a remote signer server
+| `--remote-signer-key-path`     | /path/to/client.key for establishing a secure, TLS gRPC connection to a remote signer server
+| `--remote-signer-ca-crt-path`     | /path/to/ca.crt for establishing a secure, TLS gRPC connection to a remote signer server
 
 ### List validator accounts
 
@@ -128,5 +141,3 @@ You can view all available options to run the `list` command by typing `./prysm.
 | Flag          | Usage         |
 | ------------- |:-------------|
 | `--wallet-dir` | Path to a wallet directory (default: "$HOME/Eth2Validators/prysm-wallet-v2")
-| `--passwords-dir`     | Path to a directory where account passwords will be stored (default: "$HOME/Eth2Validators/prysm-wallet-passwords")
-| `--show-deposit-data`     |  Display raw eth1 tx deposit data for validator accounts-v2 (default: false

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -37,7 +37,12 @@
 								"faq"
 							],
 
-
+		"Wallet and accounts": 	[   
+			"wallet/introduction",
+			"wallet/deterministic",
+			"wallet/nondeterministic",
+			"wallet/remote"
+		],
 
 		"How Prysm works": 	[	"how-prysm-works/architecture-overview",
 								"how-prysm-works/beacon-node",


### PR DESCRIPTION
This PR starts the required documentation for Prysm's accounts-v2 revamp, including new ways of generating wallets, accounts, and more. This PR will be the feature branch used to include all accounts-v2 docs before we push to production.