### PR TITLE
Update medalla.md with missing newlines

### DIFF
--- a/website/docs/testnet/medalla.md
+++ b/website/docs/testnet/medalla.md
@@ -259,10 +259,10 @@ Open a second terminal window. Depending on your platform, issue the appropriate
 
 ```text
 docker run -it -v $HOME/Eth2Validators/prysm-wallet-v2:/wallet --network="host" \
-  -v $HOME/Eth2Validators/prysm-wallet-v2-passwords:/eth2passwords
+  -v $HOME/Eth2Validators/prysm-wallet-v2-passwords:/eth2passwords \
   gcr.io/prysmaticlabs/prysm/validator:latest \
   --beacon-rpc-provider=127.0.0.1:4000 \
-  --wallet-dir=/wallet
+  --wallet-dir=/wallet \
   --passwords-dir=/eth2passwords
 ```
 


### PR DESCRIPTION
The script does not run without the newline characters.

Note that I was easily able to setup an Eth2.0 Medala validator node by using this Dockerfile that I created https://github.com/ethereum/eth2.0-deposit-cli/pull/83, along with your Docker instructions.  