### PR TITLE
Fixed line break on command

### DIFF
--- a/website/docs/testnet/medalla.md
+++ b/website/docs/testnet/medalla.md
@@ -300,10 +300,10 @@ docker run -it -v %LOCALAPPDATA%\Eth2Validators\prysm-wallet-v2:/wallet -v %LOCA
 
 ```text
 docker run -it -v $HOME/Eth2Validators/prysm-wallet-v2:/wallet --network="host" \
-  -v $HOME/Eth2Validators/prysm-wallet-v2-passwords:/eth2passwords
+  -v $HOME/Eth2Validators/prysm-wallet-v2-passwords:/eth2passwords \
   gcr.io/prysmaticlabs/prysm/validator:latest \
   --beacon-rpc-provider=127.0.0.1:4000 \
-  --wallet-dir=/wallet
+  --wallet-dir=/wallet \
   --passwords-dir=/eth2passwords
 ```
 


### PR DESCRIPTION
When people would copy & paste the docker command the shell would not be able to process it without the right line breaks.

