### PR TITLE
Fix command line break for Linux tab

### DIFF
--- a/website/docs/testnet/medalla.md
+++ b/website/docs/testnet/medalla.md
@@ -259,10 +259,10 @@ Open a second terminal window. Depending on your platform, issue the appropriate
 
 ```text
 docker run -it -v $HOME/Eth2Validators/prysm-wallet-v2:/wallet --network="host" \
-  -v $HOME/Eth2Validators/prysm-wallet-v2-passwords:/eth2passwords
+  -v $HOME/Eth2Validators/prysm-wallet-v2-passwords:/eth2passwords \
   gcr.io/prysmaticlabs/prysm/validator:latest \
   --beacon-rpc-provider=127.0.0.1:4000 \
-  --wallet-dir=/wallet
+  --wallet-dir=/wallet \
   --passwords-dir=/eth2passwords
 ```
 


### PR DESCRIPTION
Previous PR #205 fixed this for the Mac tab. I though it would share this with the Linux version of the documentation, because it's the same command. This now fixes the same issue in the Linux documentation.