### PR TITLE
Remove prysm-wallet-v2-passwords from docker validator instructions

### DIFF
--- a/website/docs/testnet/medalla.md
+++ b/website/docs/testnet/medalla.md
@@ -124,6 +124,7 @@ bazel run //validator:validator -- accounts-v2 import --keys-dir=$HOME/eth2.0-de
 
 ![image](https://i.imgur.com/3yH946I.png)
 
+#### Beacon node
 First, let's run the beacon node connected to the medalla testnet. It will begin to sync with other nodes and will be ready for you to connect to it.  If your beacon node is still running from [Step 1](https://docs.prylabs.network/docs/testnet/medalla#step-1-get-prysm), you do not have to perform this portion of Step 5.  Skip to the [validator portion](#validatorPortion).
 
 <Tabs
@@ -228,12 +229,14 @@ bazel run //beacon-chain
 </TabItem>
 </Tabs>
 
-
 :::tip Syncing your node
 The beacon-chain node you are using should be **completely synced** before submitting your deposit. You may **incur minor inactivity balance penalties** if the validator is unable to perform its duties by the time the deposit is processed and activated by the ETH2 network. You do not need to worry about this if the chain has not started yet.
 :::
+<a name="validatorPortion"></a>
 
-<a name="validatorPortion"></a>Open a second terminal window. Depending on your platform, issue the appropriate command from the examples below to start the validator.
+
+#### Validator
+Open a second terminal window. Depending on your platform, issue the appropriate command from the examples below to start the validator.
 
 <Tabs
   groupId="operating-systems"

--- a/website/docs/testnet/medalla.md
+++ b/website/docs/testnet/medalla.md
@@ -125,7 +125,7 @@ bazel run //validator:validator -- accounts-v2 import --keys-dir=$HOME/eth2.0-de
 ![image](https://i.imgur.com/3yH946I.png)
 
 #### Beacon node
-First, let's run the beacon node connected to the medalla testnet. It will begin to sync with other nodes and will be ready for you to connect to it.  If your beacon node is still running from [Step 1](https://docs.prylabs.network/docs/testnet/medalla#step-1-get-prysm), you do not have to perform this portion of Step 5.  Skip to the [validator portion](#validatorPortion).
+First, let's run the beacon node connected to the medalla testnet. It will begin to sync with other nodes and will be ready for you to connect to it.  If your beacon node is still running from [Step 1](https://docs.prylabs.network/docs/testnet/medalla#step-1-get-prysm), you do not have to perform this portion of Step 5.  Skip to the [validator portion](#validator).
 
 <Tabs
   groupId="operating-systems"
@@ -232,8 +232,6 @@ bazel run //beacon-chain
 :::tip Syncing your node
 The beacon-chain node you are using should be **completely synced** before submitting your deposit. You may **incur minor inactivity balance penalties** if the validator is unable to perform its duties by the time the deposit is processed and activated by the ETH2 network. You do not need to worry about this if the chain has not started yet.
 :::
-<a name="validatorPortion"></a>
-
 
 #### Validator
 Open a second terminal window. Depending on your platform, issue the appropriate command from the examples below to start the validator.

--- a/website/docs/testnet/medalla.md
+++ b/website/docs/testnet/medalla.md
@@ -53,9 +53,8 @@ import TabItem from '@theme/TabItem';
 ```text
 docker run -it -v $HOME/eth2.0-deposit-cli/validator_keys:/keys \
   -v $HOME/Eth2Validators/prysm-wallet-v2:/wallet \
-  -v $HOME/Eth2Validators/prysm-wallet-v2-passwords:/eth2passwords \
   gcr.io/prysmaticlabs/prysm/validator:latest \
-  accounts-v2 import --keys-dir=/keys --wallet-dir=/wallet --passwords-dir=/eth2passwords
+  accounts-v2 import --keys-dir=/keys --wallet-dir=/wallet
 ```
 
 **Using Bazel**
@@ -76,7 +75,7 @@ prysm.bat validator accounts-v2 import --keys-dir=%LOCALAPPDATA%\eth2.0-deposit-
 **Using Docker**
 
 ```text
-docker run -it -v %LOCALAPPDATA%\eth2.0-deposit-cli\validator_keys:/keys -v %LOCALAPPDATA%\Eth2Validators\prysm-wallet-v2:/wallet -v %LOCALAPPDATA%\Eth2Validators\prysm-wallet-v2-passwords:/eth2passwords gcr.io/prysmaticlabs/prysm/validator:latest accounts-v2 import --keys-dir=/keys --wallet-dir=/wallet --passwords-dir=/eth2passwords
+docker run -it -v %LOCALAPPDATA%\eth2.0-deposit-cli\validator_keys:/keys -v %LOCALAPPDATA%\Eth2Validators\prysm-wallet-v2:/wallet gcr.io/prysmaticlabs/prysm/validator:latest accounts-v2 import --keys-dir=/keys --wallet-dir=/wallet
 ```
 
 </TabItem>
@@ -93,9 +92,8 @@ docker run -it -v %LOCALAPPDATA%\eth2.0-deposit-cli\validator_keys:/keys -v %LOC
 ```text
 docker run -it -v $HOME/eth2.0-deposit-cli/validator_keys:/keys \
   -v $HOME/Eth2Validators/prysm-wallet-v2:/wallet \
-  -v $HOME/Eth2Validators/prysm-wallet-v2-passwords:/eth2passwords \
   gcr.io/prysmaticlabs/prysm/validator:latest \
-  accounts-v2 import --keys-dir=/keys --wallet-dir=/wallet --passwords-dir=/eth2passwords
+  accounts-v2 import --keys-dir=/keys --wallet-dir=/wallet
 ```
 
 **Using Bazel**
@@ -259,11 +257,9 @@ Open a second terminal window. Depending on your platform, issue the appropriate
 
 ```text
 docker run -it -v $HOME/Eth2Validators/prysm-wallet-v2:/wallet --network="host" \
-  -v $HOME/Eth2Validators/prysm-wallet-v2-passwords:/eth2passwords \
   gcr.io/prysmaticlabs/prysm/validator:latest \
   --beacon-rpc-provider=127.0.0.1:4000 \
-  --wallet-dir=/wallet \
-  --passwords-dir=/eth2passwords
+  --wallet-dir=/wallet
 ```
 
 **Using Bazel**
@@ -284,7 +280,7 @@ prysm.bat validator
 **Using Docker**
 
 ```text
-docker run -it -v %LOCALAPPDATA%\Eth2Validators\prysm-wallet-v2:/wallet -v %LOCALAPPDATA%\Eth2Validators\prysm-wallet-v2-passwords:/eth2passwords --network="host" gcr.io/prysmaticlabs/prysm/validator:latest --beacon-rpc-provider=127.0.0.1:4000 --wallet-dir=/wallet --passwords-dir=/eth2passwords
+docker run -it -v %LOCALAPPDATA%\Eth2Validators\prysm-wallet-v2:/wallet --network="host" gcr.io/prysmaticlabs/prysm/validator:latest --beacon-rpc-provider=127.0.0.1:4000 --wallet-dir=/wallet
 ```
 
 </TabItem>
@@ -300,11 +296,9 @@ docker run -it -v %LOCALAPPDATA%\Eth2Validators\prysm-wallet-v2:/wallet -v %LOCA
 
 ```text
 docker run -it -v $HOME/Eth2Validators/prysm-wallet-v2:/wallet --network="host" \
-  -v $HOME/Eth2Validators/prysm-wallet-v2-passwords:/eth2passwords \
   gcr.io/prysmaticlabs/prysm/validator:latest \
   --beacon-rpc-provider=127.0.0.1:4000 \
-  --wallet-dir=/wallet \
-  --passwords-dir=/eth2passwords
+  --wallet-dir=/wallet
 ```
 
 **Using Bazel**

--- a/website/docs/testnet/medalla.md
+++ b/website/docs/testnet/medalla.md
@@ -124,7 +124,7 @@ bazel run //validator:validator -- accounts-v2 import --keys-dir=$HOME/eth2.0-de
 
 ![image](https://i.imgur.com/3yH946I.png)
 
-First, let's run the beacon node connected to the medalla testnet. It will begin to sync with other nodes and will be ready for you to connect to it.  If your beacon node is still running from [Step 1](https://docs.prylabs.network/docs/testnet/medalla#step-1-get-prysm), you do not have to perform this step.
+First, let's run the beacon node connected to the medalla testnet. It will begin to sync with other nodes and will be ready for you to connect to it.  If your beacon node is still running from [Step 1](https://docs.prylabs.network/docs/testnet/medalla#step-1-get-prysm), you do not have to perform this portion of Step 5.  Skip to the [validator portion](#validatorPortion).
 
 <Tabs
   groupId="operating-systems"
@@ -233,7 +233,7 @@ bazel run //beacon-chain
 The beacon-chain node you are using should be **completely synced** before submitting your deposit. You may **incur minor inactivity balance penalties** if the validator is unable to perform its duties by the time the deposit is processed and activated by the ETH2 network. You do not need to worry about this if the chain has not started yet.
 :::
 
-Open a second terminal window. Depending on your platform, issue the appropriate command from the examples below to start the validator.
+<a name="validatorPortion"></a>Open a second terminal window. Depending on your platform, issue the appropriate command from the examples below to start the validator.
 
 <Tabs
   groupId="operating-systems"

--- a/website/docs/testnet/medalla.md
+++ b/website/docs/testnet/medalla.md
@@ -124,7 +124,7 @@ bazel run //validator:validator -- accounts-v2 import --keys-dir=$HOME/eth2.0-de
 
 ![image](https://i.imgur.com/3yH946I.png)
 
-First, let's run the beacon node connected to the medalla testnet. It will begin to sync with other nodes and will be ready for you to connect to it.
+First, let's run the beacon node connected to the medalla testnet. It will begin to sync with other nodes and will be ready for you to connect to it.  If your beacon node is still running from [Step 1](https://docs.prylabs.network/docs/testnet/medalla#step-1-get-prysm), you do not have to perform this step.
 
 <Tabs
   groupId="operating-systems"


### PR DESCRIPTION
Removes the passwords directory from the docker-specific instructions as it is no longer used.

Also:  as all the docker validator instructions are for interactive runs, no need to create and include --wallet-password-file in these instructions.  Users will interactively provide the wallet password.