### PR TITLE
Modify links on grafana-dashboard page

### DIFF
--- a/website/docs/prysm-usage/monitoring/grafana-dashboard.md
+++ b/website/docs/prysm-usage/monitoring/grafana-dashboard.md
@@ -120,8 +120,8 @@ A green notification saying “Datasource updated” should now be visible on th
 ## Creating and importing dashboards
 
 1. The dashboard can now be customised to the users preferences. There are two examples that can be used:
-- [dashboard designed for small amount of validator keys](http://localhost:3000/assets/grafana-dashboards/small_amount_validators.json)
-- [dashboard designed for more than 10 validator keys](http://localhost:3000/assets/grafana-dashboards/big_amount_validators.json)
+- [dashboard designed for small amount of validator keys](https://docs.prylabs.network/assets/grafana-dashboards/small_amount_validators.json)
+- [dashboard designed for more than 10 validator keys](https://docs.prylabs.network/assets/grafana-dashboards/big_amount_validators.json)
 
 2. To import this json into the Grafana dashboard, click on the **+** icon on the left menu and select 'Import', 
 
@@ -131,10 +131,10 @@ A green notification saying “Datasource updated” should now be visible on th
 
 For those running their node and validators on separate machines, simply modify the pasted `prometheus.yml` data from the earlier step and change any instances of `localhost` to the desired IP. For local networks, the _private IP_ is required. For connections over the internet, the _public facing IP_ will be required.
 
-* [Finding a **private IP**](https://docs.prylabs.network/docs/prysm-usage/p2p-host-ip/#private-ip-addresses)
-* [Finding a **public IP**](https://docs.prylabs.network/docs/prysm-usage/p2p-host-ip/#public-ip-addresses)
+* [Finding a **private IP**](/docs/prysm-usage/p2p-host-ip/#private-ip-addresses)
+* [Finding a **public IP**](/docs/prysm-usage/p2p-host-ip/#public-ip-addresses)
 
-> **NOTICE:** In case of public IPs, [port forwarding](https://docs.prylabs.network/docs/prysm-usage/p2p-host-ip/#port-forwarding) may need to be configured.
+> **NOTICE:** In case of public IPs, [port forwarding](/docs/prysm-usage/p2p-host-ip/#port-forwarding) may need to be configured.
 
 ## Activate currency converter feature
-A specific [guide](https://docs.prylabs.network/docs/prysm-usage/monitoring/currency-converter/) has been designed for it
+A specific [guide](/docs/prysm-usage/monitoring/currency-converter/) has been designed for it


### PR DESCRIPTION
Fixes issues with `localhost` links (although this is not the cleanest of solutions) and changes some absolute links to relative ones.