### PR TITLE
Enforce Eth1 Endpoint in Docs + Ordering of Node Syncing

### DIFF
--- a/website/docs/install/install-with-bazel.md
+++ b/website/docs/install/install-with-bazel.md
@@ -71,10 +71,12 @@ Below are instructions for initialising a beacon node and connecting to the publ
 It is recommended to open up port tcp/13000 and udp/12000 on your local router to improve connectivity and receive more peers from the network. To do so, navigate to `192.168.0.1` in your browser and login if required. Follow along with the interface to modify your routers firewall settings. When this task is completed, append the parameter`--p2p-host-ip=$(curl -s ident.me)` to your selected beacon startup command presented in this section to use the newly opened port.
 :::
 
+You will need to setup an eth1 node connection to run a beacon node. We have dedicated instructions for this step [here](/docs/prysm-usage/setup-eth1)
+
 To start your [beacon node](/docs/how-prysm-works/beacon-node) with Bazel, issue the following command:
 
 ```text
-bazel run //beacon-chain -- --datadir=$HOME/.eth2 
+bazel run //beacon-chain -- --datadir=$HOME/.eth2 --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT>
 ```
 
 This will sync up the beacon node with the latest head block in the network. If the network hasn't started yet, it will process eth1 deposits from the deposit contract so far and await the genesis time.

--- a/website/docs/install/install-with-docker.md
+++ b/website/docs/install/install-with-docker.md
@@ -83,6 +83,8 @@ Below are instructions for initialising a beacon node and connecting to the publ
 It is recommended to open up port tcp/13000 and udp/12000 on your local router to improve connectivity and receive more peers from the network. To do so, navigate to `192.168.0.1` in your browser and login if required. Follow along with the interface to modify your routers firewall settings. When this task is completed, append the parameter`--p2p-host-ip=$(curl -s ident.me)` to your selected beacon startup command presented in this section to use the newly opened port.
 :::
 
+You will need to setup an eth1 node connection to run a beacon node. We have dedicated instructions for this step [here](/docs/prysm-usage/setup-eth1).
+
 To start your beacon node, issue the following command:
 
 ```text
@@ -90,7 +92,8 @@ docker run -it -v $HOME/.eth2:/data -p 4000:4000 -p 13000:13000 -p 12000:12000/u
   gcr.io/prysmaticlabs/prysm/beacon-chain:latest \
   --datadir=/data \
   --rpc-host=0.0.0.0 \
-  --monitoring-host=0.0.0.0
+  --monitoring-host=0.0.0.0 \
+  --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT>
 ```
 
 At this point, the beacon chain data will begin synchroni zing up to the latest head block. Please note that, depending on your network capacity and CPU, this process may take several hours. Once it is complete, you will be ready to make a deposit and begin setting up a validator client.
@@ -131,7 +134,8 @@ docker run -it -v $HOME/.eth2:/data -p 4000:4000 -p 13000:13000 -p 12000:12000/u
   --datadir=/data \
   --clear-db \
   --rpc-host=0.0.0.0 \
-  --monitoring-host=0.0.0.0
+  --monitoring-host=0.0.0.0 \
+  --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT>
 ```
 </TabItem>
 <TabItem value="win">
@@ -166,10 +170,11 @@ Below are instructions for initialising a beacon node and connecting to the publ
    3. Select a drive to share
    4. Click 'Apply'
 2. You will next need to create a directory named `/prysm/` within your selected shared Drive. This folder will be used as a local data directory for [beacon node](/docs/how-prysm-works/beacon-node) chain data as well as account and keystore information required by the validator. Docker **will not** create this directory if it does not exist already. For the purposes of these instructions, it is assumed that `C:` is your prior-selected shared Drive.
-3. To run the beacon node, issue the following command:
+3. You will need to setup an eth1 node connection to run a beacon node. We have dedicated instructions for this step [here](/docs/prysm-usage/setup-eth1)
+4. To run the beacon node, issue the following command:
 
 ```text
-docker run -it -v %LOCALAPPDATA%\Eth2:/data -p 4000:4000 -p 13000:13000 -p 12000:12000/udp gcr.io/prysmaticlabs/prysm/beacon-chain:latest --datadir=/data --rpc-host=0.0.0.0 --monitoring-host=0.0.0.0
+docker run -it -v %LOCALAPPDATA%\Eth2:/data -p 4000:4000 -p 13000:13000 -p 12000:12000/udp gcr.io/prysmaticlabs/prysm/beacon-chain:latest --datadir=/data --rpc-host=0.0.0.0 --monitoring-host=0.0.0.0 --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT>
 ```
 
 This will sync up the beacon node with the latest cannonical head block in the network. If the network hasn't started yet, it will process eth1 deposits from the deposit contract so far and await the genesis time. The Docker `-d` flag can be appended before the `-v` flag to launch the process in a detached terminal window. Please note that, depending on your network capacity and CPU, this process may take several hours. Once it is complete, you will be ready to make a deposit and begin setting up a validator client.
@@ -205,7 +210,7 @@ docker rm beacon-node
 To recreate a deleted container and refresh the chain database, issue the start command with an additional `--clear-db` parameter:
 
 ```text
-docker run -it -v %LOCALAPPDATA%\Eth2:/data -p 4000:4000 -p 13000:13000 -p 12000:12000/udp --name beacon-node gcr.io/prysmaticlabs/prysm/beacon-chain:latest --datadir=/data --clear-db --monitoring-host=0.0.0.0 --rpc-host=0.0.0.0
+docker run -it -v %LOCALAPPDATA%\Eth2:/data -p 4000:4000 -p 13000:13000 -p 12000:12000/udp --name beacon-node gcr.io/prysmaticlabs/prysm/beacon-chain:latest --datadir=/data --clear-db --monitoring-host=0.0.0.0 --rpc-host=0.0.0.0 --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT>
 ```
 
 </TabItem>
@@ -234,6 +239,8 @@ Below are instructions for initialising a beacon node and connecting to the publ
 It is recommended to open up port tcp/13000 and udp/12000 on your local router to improve connectivity and receive more peers from the network. To do so, navigate to `192.168.0.1` in your browser and login if required. Follow along with the interface to modify your routers firewall settings. When this task is completed, append the parameter`--p2p-host-ip=$(curl -s ident.me)` to your selected beacon startup command presented in this section to use the newly opened port.
 :::
 
+You will need to setup an eth1 node connection to run a beacon node. We have dedicated instructions for this step [here](/docs/prysm-usage/setup-eth1).
+
 To start your beacon node, issue the following command:
 
 ```text
@@ -241,7 +248,8 @@ docker run -it -v $HOME/.eth2:/data -p 4000:4000 -p 13000:13000 -p 12000:12000/u
   gcr.io/prysmaticlabs/prysm/beacon-chain:latest \
   --datadir=/data \
   --rpc-host=0.0.0.0 \
-  --monitoring-host=0.0.0.0
+  --monitoring-host=0.0.0.0 \
+  --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT>
 ```
 
 This will sync up the beacon node with the latest cannonical head block in the network. If the network hasn't started yet, it will process eth1 deposits from the deposit contract so far and await the genesis time. The Docker `-d` flag can be appended before the `-v` flag to launch the process in a detached terminal window. Please note that, depending on your network capacity and CPU, this process may take several hours. Once it is complete, you will be ready to make a deposit and begin setting up a validator client.
@@ -282,7 +290,8 @@ docker run -it -v $HOME/.eth2:/data -p 4000:4000 -p 13000:13000 -p 12000:12000/u
   --datadir=/data \
   --clear-db \
   --rpc-host=0.0.0.0 \
-  --monitoring-host=0.0.0.0
+  --monitoring-host=0.0.0.0 \
+  --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT>
 ```
 
 </TabItem>

--- a/website/docs/install/install-with-script.md
+++ b/website/docs/install/install-with-script.md
@@ -64,10 +64,10 @@ mkdir prysm && cd prysm
 curl https://raw.githubusercontent.com/prysmaticlabs/prysm/master/prysm.sh --output prysm.sh && chmod +x prysm.sh
 ```
 
-3. Run the `prysm.sh` script alongside any [startup parameters](/docs/prysm-usage/parameters#beacon-node-parameters):
+3. Run the `prysm.sh` script alongside any [startup parameters](/docs/prysm-usage/parameters#beacon-node-parameters). You will need to setup an eth1 node connection to run a beacon node. We have dedicated instructions for this step [here](/docs/prysm-usage/setup-eth1).
 
 ```sh
-./prysm.sh beacon-chain
+./prysm.sh beacon-chain --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT>
 ```
 
 :::tip Pro-Tip
@@ -77,7 +77,7 @@ Not getting enough peers?  Refer to the [improve P2P connectivity](/docs/prysm-u
 The `prysm.sh` script will now download and initialize the beacon chain with the specified parameters. The terminal will produce output like so:
 
 ```sh
-./prysm.sh beacon-chain
+./prysm.sh beacon-chain --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT>
 Latest Prysm version is v0.3.3.
 Downloading beacon chain@v0.3.3 to /home/{USER}/prysm/dist/beacon-chain-v0.3.3-linux-amd64 (automatically selected latest available version)
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
@@ -113,10 +113,10 @@ curl https://raw.githubusercontent.com/prysmaticlabs/prysm/master/prysm.bat --ou
 reg add HKCU\Console /v VirtualTerminalLevel /t REG_DWORD /d 1
 ``` 
 
-4. Run the `prysm.bat` script alongside any [startup parameters](/docs/prysm-usage/parameters#beacon-node-parameters):
+4. Run the `prysm.bat` script alongside any [startup parameters](/docs/prysm-usage/parameters#beacon-node-parameters). You will need to setup an eth1 node connection to run a beacon node. We have dedicated instructions for this step [here](/docs/prysm-usage/setup-eth1).
 
 ```sh
-.\prysm.bat beacon-chain
+.\prysm.bat beacon-chain --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT>
 ```
 
 :::tip Pro-Tip
@@ -126,7 +126,7 @@ Not getting enough peers?  Refer to the [improve P2P connectivity](/docs/prysm-u
 The `prysm.bat` script will now download and initialise the beacon chain with the specified parameters. The terminal will produce output like so:
 
 ```sh
-.\prysm.bat beacon-chain
+.\prysm.bat beacon-chain --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT>
 Latest prysm release is v1.0.0-alpha.5.
 Using prysm version v1.0.0-alpha.5.
 Downloading beacon chain v1.0.0-alpha.5 to .\dist\validator-v1.0.0-alpha.5-windows-amd64.exe automatically selected latest available release
@@ -166,10 +166,10 @@ mkdir prysm && cd prysm
 curl https://raw.githubusercontent.com/prysmaticlabs/prysm/master/prysm.sh --output prysm.sh && chmod +x prysm.sh
 ```
 
-3. Run the `prysm.sh` script alongside any [startup parameters](/docs/prysm-usage/parameters#beacon-node-parameters):
+3. Run the `prysm.sh` script alongside any [startup parameters](/docs/prysm-usage/parameters#beacon-node-parameters). You will need to setup an eth1 node connection to run a beacon node. We have dedicated instructions for this step [here](/docs/prysm-usage/setup-eth1).
 
 ```sh
-./prysm.sh beacon-chain
+./prysm.sh beacon-chain --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT>
 ```
 
 :::tip Pro-Tip
@@ -179,7 +179,7 @@ Not getting enough peers?  Refer to the [improve P2P connectivity](/docs/prysm-u
 The `prysm.sh` script will now download and initialise the beacon chain with the specified parameters. The terminal will produce output like so:
 
 ```sh
-./prysm.sh beacon-chain
+./prysm.sh beacon-chain --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT>
 Latest Prysm version is v0.3.3.
 Downloading beacon chain@v0.3.3 to /home/{USER}/prysm/dist/beacon-chain-v0.3.3-linux-amd64 (automatically selected latest available version)
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
@@ -210,10 +210,10 @@ mkdir prysm && cd prysm
 curl https://raw.githubusercontent.com/prysmaticlabs/prysm/master/prysm.sh --output prysm.sh && chmod +x prysm.sh
 ```
 
-3. Run the `prysm.sh` script alongside any [startup parameters](/docs/prysm-usage/parameters#beacon-node-parameters):
+3. Run the `prysm.sh` script alongside any [startup parameters](/docs/prysm-usage/parameters#beacon-node-parameters). You will need to setup an eth1 node connection to run a beacon node. We have dedicated instructions for this step [here](/docs/prysm-usage/setup-eth1).
 
 ```sh
-./prysm.sh beacon-chain
+./prysm.sh beacon-chain --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT>
 ```
 
 :::tip Pro-Tip
@@ -223,7 +223,7 @@ Not getting enough peers?  Refer to the [improve P2P connectivity](/docs/prysm-u
 The `prysm.sh` script will now download and initialise the beacon chain with the specified parameters. The terminal will produce output like so:
 
 ```sh
-./prysm.sh beacon-chain
+./prysm.sh beacon-chain --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT>
 Latest Prysm version is v0.3.3.
 Downloading beacon chain@v0.3.3 to /home/{USER}/prysm/dist/beacon-chain-v0.3.3-linux-amd64 (automatically selected latest available version)
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current

--- a/website/docs/prysm-usage/parameters.md
+++ b/website/docs/prysm-usage/parameters.md
@@ -81,8 +81,7 @@ These flags are specific to launching the beacon node.
 | Flag        | Usage           |
 | ------------- |:-------------|
 | `--no-custom-config` | Run the beacon chain with the real Phase 0 parameters.
-| `--http-web3provider` | Define a mainchain web3 provider string http endpoint. Default:  https://goerli.prylabs.net
-| `--web3provider` | Define a mainchain web3 provider string endpoint. Can be either a IPC file string or a WebSocket endpoint. Cannot be an HTTP endpoint. Default: wss://goerli.prylabs.net/websocket
+| `--http-web3provider` | Define an eth1 web3 provider string http endpoint. See [here](/docs/prysm-usage/setup-eth1)
 | `--deposit-contract` |Define a deposit contract address. Beacon chain node will listen logs coming from the deposit contract to determine when validator is eligible to participate.
 | `--rpc-host` | Define an address of the host on which the RPC server should listen. Default: 0.0.0.0
 | `--rpc-port` | Define a RPC port to be exposed by the beacon node. >Value: 4000

--- a/website/docs/testnet/medalla.md
+++ b/website/docs/testnet/medalla.md
@@ -8,7 +8,7 @@ This section outlines the step-by-step process for how to join the [Medalla mult
 ![image](https://i.imgur.com/3oUwf4N.png)
 
 :::danger Ensure You Are Joining the Right Testnet
-Medalla is the long-lasting, multiclient testnet. If this isn't the testnet you wish to join, but instead participate in the smaller spadina testnet, follow our instructions [here](/docs/testnet/spadina).
+Medalla is the long-lasting, multiclient testnet. If this isn't the testnet you wish to join, but instead participate in the smaller Zinken testnet, follow our instructions [here](/docs/testnet/zinken).
 :::
 
 ## Step 1: Get Prysm
@@ -23,11 +23,127 @@ To begin, follow the instructions to fetch and install Prysm for your operating 
 
 To participate in eth2, you'll need to stake 32 ETH. For the Medalla eth2 testnet, we use test ETH from the Görli eth1 testnet. You can request this testnet ETH by joining our [discord server](https://discord.gg/hmq4y2P).
 
-## Step 3: Complete the onboarding process in the official eth2 launchpad
+## Step 3: Run your beacon node
+
+![image](https://i.imgur.com/3yH946I.png)
+
+#### Beacon node
+
+First, let's run the beacon node connected to the medalla testnet. It will begin to sync with other nodes and will be ready for you to connect to it.  If your beacon node is still running from [Step 1](https://docs.prylabs.network/docs/testnet/medalla#step-1-get-prysm), you do not have to perform this section. To run a beacon node, you will need access to an eth1 node. We have dedicated instructions for this [here](/docs/prysm-usage/setup-eth1).
+
+<Tabs
+  groupId="operating-systems"
+  defaultValue="lin"
+  values={[
+    {label: 'Linux', value: 'lin'},
+    {label: 'Windows', value: 'win'},
+    {label: 'MacOS', value: 'mac'},
+    {label: 'Arm64', value: 'arm'},
+  ]
+}>
+<TabItem value="lin">
+
+**Using the Prysm installation script**
+
+```text
+./prysm.sh beacon-chain --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT>
+```
+
+**Using Docker**
+
+```text
+docker run -it -v $HOME/.eth2:/data -p 4000:4000 -p 13000:13000 -p 12000:12000/udp --name beacon-node \
+  gcr.io/prysmaticlabs/prysm/beacon-chain:latest \
+  --datadir=/data \
+  --rpc-host=0.0.0.0 \
+  --monitoring-host=0.0.0.0 \
+  --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT>
+```
+
+**Using Bazel**
+
+```text
+bazel run //beacon-chain --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT>
+```
+
+</TabItem>
+<TabItem value="win">
+
+**Using the Prysm installation script**
+
+```text
+prysm.bat beacon-chain --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT>
+```
+
+**Using Docker**
+
+1. You will need to share the local drive you wish to mount to to container \(e.g. C:\).
+   1. Enter Docker settings \(right click the tray icon\)
+   2. Click 'Shared Drives'
+   3. Select a drive to share
+   4. Click 'Apply'
+2. You will next need to create a directory named `/prysm/` within your selected shared Drive. This folder will be used as a local data directory for [beacon node](/docs/how-prysm-works/beacon-node) chain data as well as account and keystore information required by the validator. Docker **will not** create this directory if it does not exist already. For the purposes of these instructions, it is assumed that `C:` is your prior-selected shared Drive.
+3. To run the beacon node, issue the following command:
+
+```text
+docker run -it -v %LOCALAPPDATA%\Eth2:/data -p 4000:4000 -p 13000:13000 -p 12000:12000/udp gcr.io/prysmaticlabs/prysm/beacon-chain:latest --datadir=/data --rpc-host=0.0.0.0 --monitoring-host=0.0.0.0 --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT>
+```
+
+This will sync up the beacon node with the latest cannonical head block in the network. The Docker `-d` flag can be appended before the `-v` flag to launch the process in a detached terminal window.
+
+</TabItem>
+<TabItem value="mac">
+
+**Using the Prysm installation script**
+
+```text
+./prysm.sh beacon-chain --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT>
+```
+
+**Using Docker**
+
+```text
+docker run -it -v $HOME/.eth2:/data -p 4000:4000 -p 13000:13000 -p 12000:12000/udp --name beacon-node \
+  gcr.io/prysmaticlabs/prysm/beacon-chain:latest \
+  --datadir=/data \
+  --rpc-host=0.0.0.0 \
+  --monitoring-host=0.0.0.0 \
+  --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT>
+```
+
+**Using Bazel**
+
+```text
+bazel run //beacon-chain --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT>
+```
+
+</TabItem>
+<TabItem value="arm">
+
+**Using the Prysm installation script**
+
+```text
+./prysm.sh beacon-chain --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT>
+```
+
+**Using Bazel**
+
+```text
+bazel run //beacon-chain --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT>
+```
+
+</TabItem>
+</Tabs>
+
+:::tip Syncing your node
+The beacon-chain node you are using should be **completely synced** before submitting your deposit. You may **incur minor inactivity balance penalties** if the validator is unable to perform its duties by the time the deposit is processed and activated by the ETH2 network. You do not need to worry about this if the chain has not started yet.
+:::
+
+## Step 4: Complete the onboarding process in the official eth2 launchpad
 
 The [official eth2 launchpad](https://medalla.launchpad.ethereum.org/summary) is the easiest way to go through a step-by-step process to deposit your 32 ETH to become a validator. Throughout the process, you'll be asked to generate new validator credentials using the official Ethereum deposit command-line-tool [here](https://github.com/ethereum/eth2.0-deposit-cli). During the process, you will have generated a `validator_keys` folder under the `eth2.0-deposit-cli` directory. You can import all of your validator accounts into Prysm from that folder in the next step.
 
-## Step 4: Import your validator accounts into Prysm
+## Step 5: Import your validator accounts into Prysm
 
 For this step, you'll need to copy the path to the `validator_keys` folder under the `eth2.0-deposit-cli` directory you created during the launchpad process. For example, if your eth2.0-deposit-cli installation is in your `$HOME` (or `%LOCALAPPDATA%` on Windows) directory, you can then run the following commands for your operating system
 
@@ -128,120 +244,9 @@ bazel run //validator:validator -- accounts-v2 import --keys-dir=$HOME/eth2.0-de
 </TabItem>
 </Tabs>
 
-## Step 5: Run your beacon node and validator
 
-![image](https://i.imgur.com/3yH946I.png)
+## Step 6: Run your validator
 
-#### Beacon node
-First, let's run the beacon node connected to the medalla testnet. It will begin to sync with other nodes and will be ready for you to connect to it.  If your beacon node is still running from [Step 1](https://docs.prylabs.network/docs/testnet/medalla#step-1-get-prysm), you do not have to perform this portion of Step 5.  Skip to the [validator portion](#validator).
-
-<Tabs
-  groupId="operating-systems"
-  defaultValue="lin"
-  values={[
-    {label: 'Linux', value: 'lin'},
-    {label: 'Windows', value: 'win'},
-    {label: 'MacOS', value: 'mac'},
-    {label: 'Arm64', value: 'arm'},
-  ]
-}>
-<TabItem value="lin">
-
-**Using the Prysm installation script**
-
-```text
-./prysm.sh beacon-chain
-```
-
-**Using Docker**
-
-```text
-docker run -it -v $HOME/.eth2:/data -p 4000:4000 -p 13000:13000 -p 12000:12000/udp --name beacon-node \
-  gcr.io/prysmaticlabs/prysm/beacon-chain:latest \
-  --datadir=/data \
-  --rpc-host=0.0.0.0 \
-  --monitoring-host=0.0.0.0
-```
-
-**Using Bazel**
-
-```text
-bazel run //beacon-chain
-```
-
-</TabItem>
-<TabItem value="win">
-
-**Using the Prysm installation script**
-
-```text
-prysm.bat beacon-chain
-```
-
-**Using Docker**
-
-1. You will need to share the local drive you wish to mount to to container \(e.g. C:\).
-   1. Enter Docker settings \(right click the tray icon\)
-   2. Click 'Shared Drives'
-   3. Select a drive to share
-   4. Click 'Apply'
-2. You will next need to create a directory named `/prysm/` within your selected shared Drive. This folder will be used as a local data directory for [beacon node](/docs/how-prysm-works/beacon-node) chain data as well as account and keystore information required by the validator. Docker **will not** create this directory if it does not exist already. For the purposes of these instructions, it is assumed that `C:` is your prior-selected shared Drive.
-3. To run the beacon node, issue the following command:
-
-```text
-docker run -it -v %LOCALAPPDATA%\Eth2:/data -p 4000:4000 -p 13000:13000 -p 12000:12000/udp gcr.io/prysmaticlabs/prysm/beacon-chain:latest --datadir=/data --rpc-host=0.0.0.0 --monitoring-host=0.0.0.0
-```
-
-This will sync up the beacon node with the latest cannonical head block in the network. The Docker `-d` flag can be appended before the `-v` flag to launch the process in a detached terminal window.
-
-</TabItem>
-<TabItem value="mac">
-
-**Using the Prysm installation script**
-
-```text
-./prysm.sh beacon-chain
-```
-
-**Using Docker**
-
-```text
-docker run -it -v $HOME/.eth2:/data -p 4000:4000 -p 13000:13000 -p 12000:12000/udp --name beacon-node \
-  gcr.io/prysmaticlabs/prysm/beacon-chain:latest \
-  --datadir=/data \
-  --rpc-host=0.0.0.0 \
-  --monitoring-host=0.0.0.0
-```
-
-**Using Bazel**
-
-```text
-bazel run //beacon-chain
-```
-
-</TabItem>
-<TabItem value="arm">
-
-**Using the Prysm installation script**
-
-```text
-./prysm.sh beacon-chain
-```
-
-**Using Bazel**
-
-```text
-bazel run //beacon-chain
-```
-
-</TabItem>
-</Tabs>
-
-:::tip Syncing your node
-The beacon-chain node you are using should be **completely synced** before submitting your deposit. You may **incur minor inactivity balance penalties** if the validator is unable to perform its duties by the time the deposit is processed and activated by the ETH2 network. You do not need to worry about this if the chain has not started yet.
-:::
-
-#### Validator
 Open a second terminal window. Depending on your platform, issue the appropriate command from the examples below to start the validator.
 
 <Tabs
@@ -339,7 +344,7 @@ bazel run //validator
 </Tabs>
 
 
-## Step 6: Wait for your validator assignment
+## Step 7: Wait for your validator assignment
 
 Please note that it may take from **5-12 hours** for nodes in the ETH2 network to process a deposit. In the meantime, leave both terminal windows open and running; once the node is activated by the ETH2 network, the validator will immediately begin receiving tasks and performing its responsibilities. If the chain has not yet started, it will be ready to start proposing blocks and signing votes as soon as the genesis time is reached.
 

--- a/website/docs/testnet/zinken.md
+++ b/website/docs/testnet/zinken.md
@@ -5,6 +5,12 @@ sidebar_label: Zinken Eth2 launchpad onboarding
 ---
 This section outlines the step-by-step process for how to join the [Zinken multiclient testnet](https://zinken.launchpad.ethereum.org/) to run a Prysm eth2 beacon node and validator.
 
+![image](https://i.imgur.com/3oUwf4N.png)
+
+:::danger Ensure You Are Joining the Right Testnet
+zinken is a short-lived, multiclient testnet. If this isn't the testnet you wish to join, but instead participate in the larger Medalla testnet, follow our instructions [here](/docs/testnet/medalla).
+:::
+
 ## Step 1: Get Prysm
 
 To begin, follow the instructions to fetch and install Prysm for your operating system.
@@ -15,13 +21,131 @@ To begin, follow the instructions to fetch and install Prysm for your operating 
 
 ## Step 2: Get Test ETH
 
-To participate in eth2, you'll need to stake 32 ETH. For the Zinken eth2 testnet, we use test ETH from the Görli eth1 testnet. You can request this testnet ETH by joining our [discord server](https://discord.gg/prysmaticlabs).
+To participate in eth2, you'll need to stake 32 ETH. For the zinken eth2 testnet, we use test ETH from the Görli eth1 testnet. You can request this testnet ETH by joining our [discord server](https://discord.gg/hmq4y2P).
 
-## Step 3: Complete the onboarding process in the official eth2 launchpad
+## Step 3: Run your beacon node
+
+![image](https://i.imgur.com/3yH946I.png)
+
+#### Beacon node
+
+First, let's run the beacon node connected to the zinken testnet. It will begin to sync with other nodes and will be ready for you to connect to it.  If your beacon node is still running from [Step 1](https://docs.prylabs.network/docs/testnet/zinken#step-1-get-prysm), you do not have to perform this section. To run a beacon node, you will need access to an eth1 node. We have dedicated instructions for this [here](/docs/prysm-usage/setup-eth1).
+
+<Tabs
+  groupId="operating-systems"
+  defaultValue="lin"
+  values={[
+    {label: 'Linux', value: 'lin'},
+    {label: 'Windows', value: 'win'},
+    {label: 'MacOS', value: 'mac'},
+    {label: 'Arm64', value: 'arm'},
+  ]
+}>
+<TabItem value="lin">
+
+**Using the Prysm installation script**
+
+```text
+./prysm.sh beacon-chain --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT> --zinken
+```
+
+**Using Docker**
+
+```text
+docker run -it -v $HOME/.eth2:/data -p 4000:4000 -p 13000:13000 -p 12000:12000/udp --name beacon-node \
+  gcr.io/prysmaticlabs/prysm/beacon-chain:latest \
+  --datadir=/data \
+  --rpc-host=0.0.0.0 \
+  --monitoring-host=0.0.0.0 \
+  --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT> \
+  --zinken
+```
+
+**Using Bazel**
+
+```text
+bazel run //beacon-chain --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT> --zinken
+```
+
+</TabItem>
+<TabItem value="win">
+
+**Using the Prysm installation script**
+
+```text
+prysm.bat beacon-chain --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT> --zinken
+```
+
+**Using Docker**
+
+1. You will need to share the local drive you wish to mount to to container \(e.g. C:\).
+   1. Enter Docker settings \(right click the tray icon\)
+   2. Click 'Shared Drives'
+   3. Select a drive to share
+   4. Click 'Apply'
+2. You will next need to create a directory named `/prysm/` within your selected shared Drive. This folder will be used as a local data directory for [beacon node](/docs/how-prysm-works/beacon-node) chain data as well as account and keystore information required by the validator. Docker **will not** create this directory if it does not exist already. For the purposes of these instructions, it is assumed that `C:` is your prior-selected shared Drive.
+3. To run the beacon node, issue the following command:
+
+```text
+docker run -it -v %LOCALAPPDATA%\Eth2:/data -p 4000:4000 -p 13000:13000 -p 12000:12000/udp gcr.io/prysmaticlabs/prysm/beacon-chain:latest --datadir=/data --rpc-host=0.0.0.0 --monitoring-host=0.0.0.0 --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT> --zinken
+```
+
+This will sync up the beacon node with the latest cannonical head block in the network. The Docker `-d` flag can be appended before the `-v` flag to launch the process in a detached terminal window.
+
+</TabItem>
+<TabItem value="mac">
+
+**Using the Prysm installation script**
+
+```text
+./prysm.sh beacon-chain --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT> --zinken
+```
+
+**Using Docker**
+
+```text
+docker run -it -v $HOME/.eth2:/data -p 4000:4000 -p 13000:13000 -p 12000:12000/udp --name beacon-node \
+  gcr.io/prysmaticlabs/prysm/beacon-chain:latest \
+  --datadir=/data \
+  --rpc-host=0.0.0.0 \
+  --monitoring-host=0.0.0.0 \
+  --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT> \
+  --zinken
+```
+
+**Using Bazel**
+
+```text
+bazel run //beacon-chain --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT> --zinken
+```
+
+</TabItem>
+<TabItem value="arm">
+
+**Using the Prysm installation script**
+
+```text
+./prysm.sh beacon-chain --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT> --zinken
+```
+
+**Using Bazel**
+
+```text
+bazel run //beacon-chain --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT> --zinken
+```
+
+</TabItem>
+</Tabs>
+
+:::tip Syncing your node
+The beacon-chain node you are using should be **completely synced** before submitting your deposit. You may **incur minor inactivity balance penalties** if the validator is unable to perform its duties by the time the deposit is processed and activated by the ETH2 network. You do not need to worry about this if the chain has not started yet.
+:::
+
+## Step 4: Complete the onboarding process in the official eth2 launchpad
 
 The [official eth2 launchpad](https://zinken.launchpad.ethereum.org/summary) is the easiest way to go through a step-by-step process to deposit your 32 ETH to become a validator. Throughout the process, you'll be asked to generate new validator credentials using the official Ethereum deposit command-line-tool [here](https://github.com/ethereum/eth2.0-deposit-cli). During the process, you will have generated a `validator_keys` folder under the `eth2.0-deposit-cli` directory. You can import all of your validator accounts into Prysm from that folder in the next step.
 
-## Step 4: Import your validator accounts into Prysm
+## Step 5: Import your validator accounts into Prysm
 
 For this step, you'll need to copy the path to the `validator_keys` folder under the `eth2.0-deposit-cli` directory you created during the launchpad process. For example, if your eth2.0-deposit-cli installation is in your `$HOME` (or `%LOCALAPPDATA%` on Windows) directory, you can then run the following commands for your operating system
 
@@ -122,122 +246,9 @@ bazel run //validator:validator -- accounts-v2 import --keys-dir=$HOME/eth2.0-de
 </TabItem>
 </Tabs>
 
-## Step 5: Run your beacon node and validator
 
-![image](https://i.imgur.com/3yH946I.png)
+## Step 6: Run your validator
 
-#### Beacon node
-First, let's run the beacon node connected to the Zinken testnet. It will begin to sync with other nodes and will be ready for you to connect to it.  If your beacon node is still running from [Step 1](https://docs.prylabs.network/docs/testnet/zinken#step-1-get-prysm), you do not have to perform this portion of Step 5.  Skip to the [validator portion](#validator).
-
-<Tabs
-  groupId="operating-systems"
-  defaultValue="lin"
-  values={[
-    {label: 'Linux', value: 'lin'},
-    {label: 'Windows', value: 'win'},
-    {label: 'MacOS', value: 'mac'},
-    {label: 'Arm64', value: 'arm'},
-  ]
-}>
-<TabItem value="lin">
-
-**Using the Prysm installation script**
-
-```text
-./prysm.sh beacon-chain --zinken
-```
-
-**Using Docker**
-
-```text
-docker run -it -v $HOME/.eth2:/data -p 4000:4000 -p 13000:13000 -p 12000:12000/udp --name beacon-node \
-  gcr.io/prysmaticlabs/prysm/beacon-chain:latest \
-  --datadir=/data \
-  --rpc-host=0.0.0.0 \
-  --monitoring-host=0.0.0.0 \
-  --zinken
-```
-
-**Using Bazel**
-
-```text
-bazel run //beacon-chain --zinken
-```
-
-</TabItem>
-<TabItem value="win">
-
-**Using the Prysm installation script**
-
-```text
-prysm.bat beacon-chain --zinken
-```
-
-**Using Docker**
-
-1. You will need to share the local drive you wish to mount to to container \(e.g. C:\).
-   1. Enter Docker settings \(right click the tray icon\)
-   2. Click 'Shared Drives'
-   3. Select a drive to share
-   4. Click 'Apply'
-2. You will next need to create a directory named `/prysm/` within your selected shared Drive. This folder will be used as a local data directory for [beacon node](/docs/how-prysm-works/beacon-node) chain data as well as account and keystore information required by the validator. Docker **will not** create this directory if it does not exist already. For the purposes of these instructions, it is assumed that `C:` is your prior-selected shared Drive.
-3. To run the beacon node, issue the following command:
-
-```text
-docker run -it -v %LOCALAPPDATA%\Eth2:/data -p 4000:4000 -p 13000:13000 -p 12000:12000/udp gcr.io/prysmaticlabs/prysm/beacon-chain:latest --datadir=/data --rpc-host=0.0.0.0 --monitoring-host=0.0.0.0 --zinken
-```
-
-This will sync up the beacon node with the latest cannonical head block in the network. The Docker `-d` flag can be appended before the `-v` flag to launch the process in a detached terminal window.
-
-</TabItem>
-<TabItem value="mac">
-
-**Using the Prysm installation script**
-
-```text
-./prysm.sh beacon-chain --zinken
-```
-
-**Using Docker**
-
-```text
-docker run -it -v $HOME/.eth2:/data -p 4000:4000 -p 13000:13000 -p 12000:12000/udp --name beacon-node \
-  gcr.io/prysmaticlabs/prysm/beacon-chain:latest \
-  --datadir=/data \
-  --rpc-host=0.0.0.0 \
-  --monitoring-host=0.0.0.0 \
-  --zinken
-```
-
-**Using Bazel**
-
-```text
-bazel run //beacon-chain --zinken
-```
-
-</TabItem>
-<TabItem value="arm">
-
-**Using the Prysm installation script**
-
-```text
-./prysm.sh beacon-chain --zinken
-```
-
-**Using Bazel**
-
-```text
-bazel run //beacon-chain --zinken
-```
-
-</TabItem>
-</Tabs>
-
-:::tip Syncing your node
-The beacon-chain node you are using should be **completely synced** before submitting your deposit. You may **incur minor inactivity balance penalties** if the validator is unable to perform its duties by the time the deposit is processed and activated by the ETH2 network. You do not need to worry about this if the chain has not started yet.
-:::
-
-#### Validator
 Open a second terminal window. Depending on your platform, issue the appropriate command from the examples below to start the validator.
 
 <Tabs
@@ -266,14 +277,13 @@ docker run -it -v $HOME/Eth2Validators/prysm-wallet-v2:/wallet \
   --network="host" --name validator \
   gcr.io/prysmaticlabs/prysm/validator:latest \
   --beacon-rpc-provider=127.0.0.1:4000 \
-  --wallet-dir=/wallet --datadir=/validatorDB \
-  --zinken
+  --wallet-dir=/wallet --datadir=/validatorDB --zinken
 ```
 
 **Using Bazel**
 
 ```text
-bazel run //validator --zinken
+bazel run //validator -- --zinken
 ```
 
 </TabItem>
@@ -308,14 +318,13 @@ docker run -it -v $HOME/Eth2Validators/prysm-wallet-v2:/wallet \
   --network="host" --name validator \
   gcr.io/prysmaticlabs/prysm/validator:latest \
   --beacon-rpc-provider=127.0.0.1:4000 \
-  --wallet-dir=/wallet --datadir=/validatorDB \
-  --zinken
+  --wallet-dir=/wallet --datadir=/validatorDB --zinken
 ```
 
 **Using Bazel**
 
 ```text
-bazel run //validator --zinken
+bazel run //validator -- --zinken
 ```
 
 </TabItem>
@@ -337,7 +346,7 @@ bazel run //validator --zinken
 </Tabs>
 
 
-## Step 6: Wait for your validator assignment
+## Step 7: Wait for your validator assignment
 
 Please note that it may take from **5-12 hours** for nodes in the ETH2 network to process a deposit. In the meantime, leave both terminal windows open and running; once the node is activated by the ETH2 network, the validator will immediately begin receiving tasks and performing its responsibilities. If the chain has not yet started, it will be ready to start proposing blocks and signing votes as soon as the genesis time is reached.
 

--- a/website/docs/testnet/zinken.md
+++ b/website/docs/testnet/zinken.md
@@ -5,8 +5,6 @@ sidebar_label: Zinken Eth2 launchpad onboarding
 ---
 This section outlines the step-by-step process for how to join the [Zinken multiclient testnet](https://zinken.launchpad.ethereum.org/) to run a Prysm eth2 beacon node and validator.
 
-![image](https://i.imgur.com/3oUwf4N.png)
-
 :::danger Ensure You Are Joining the Right Testnet
 zinken is a short-lived, multiclient testnet. If this isn't the testnet you wish to join, but instead participate in the larger Medalla testnet, follow our instructions [here](/docs/testnet/medalla).
 :::


### PR DESCRIPTION
Fixes #246, fixes #243 

Currently, we do not force users to add --http-web3provider to their beacon node in our docs. This PR changes this and adds a link to how to setup an eth1 node. Additionally, we change the order of recommended steps to join the testnet to recommend syncing a beacon node _first_, and then going through the launchpad process. This PR also gets rid of deprecated options in the parameters page