### PR TITLE
Up the Resource Requirement Recommendations

### DIFF
--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -45,14 +45,14 @@ Memory management is an ongoing process for our team - we are constantly working
 
 Recommended Hardware
 Processor: Intel Core i7–4770 or AMD FX-8310 or better
-Memory: 8GB RAM
+Memory: 16GB RAM
 Storage: 100GB available space SSD
 Internet: Broadband connection
 
 Minimum Hardware:
 Operating System: 64-bit Linux, Mac OS X, Windows
 Processor: Intel Core i5–760 or AMD FX-8100 or better
-Memory: 4GB RAM
+Memory: 8GB RAM
 Storage: 20GB available space SSD
 Internet: Broadband connection
 

--- a/website/docs/install/arm.md
+++ b/website/docs/install/arm.md
@@ -14,14 +14,14 @@ Prysm can be installed on ARM64 systems using the Prysm build script. This page 
 These specifications must be met in order to successfully run the Prysm client.
 * Operating System: 64-bit Linux, Mac OS X 10.14+, Windows
 * Processor: Intel Core i5–760 or AMD FX-8100 or better
-* Memory: 4GB RAM
+* Memory: 8GB RAM
 * Storage: 20GB available space SSD
 * Internet: Broadband connection
 
 ### Recommended specifications
 These hardware specifications are recommended, but not required to run the Prysm client.
 * Processor: Intel Core i7–4770 or AMD FX-8310 or better
-* Memory: 8GB RAM
+* Memory: 16GB RAM
 * Storage: 100GB available space SSD
 * Internet: Broadband connection
 

--- a/website/docs/install/install-with-bazel.md
+++ b/website/docs/install/install-with-bazel.md
@@ -20,7 +20,7 @@ These specifications must be met in order to successfully run the Prysm client.
 
 * Operating System: 64-bit GNU/Linux, MacOS
 * Processor: Intel Core i5–760 or AMD FX-8100 or better
-* Memory: 4GB RAM
+* Memory: 8GB RAM
 * Storage: 20GB available space SSD
 * Internet: Broadband connection
 
@@ -29,7 +29,7 @@ These specifications must be met in order to successfully run the Prysm client.
 These hardware specifications are recommended, but not required to run the Prysm client.
 
 * Processor: Intel Core i7–4770 or AMD FX-8310 or better
-* Memory: 8GB RAM
+* Memory: 16GB RAM
 * Storage: 100GB available space SSD
 
 ## Dependencies

--- a/website/docs/install/install-with-docker.md
+++ b/website/docs/install/install-with-docker.md
@@ -22,7 +22,7 @@ These specifications must be met in order to successfully run the Prysm client.
 
 * Operating System: 64-bit Linux, Mac OS X 10.14+, Windows 64-bit
 * Processor: Intel Core i5–760 or AMD FX-8100 or better
-* Memory: 4GB RAM
+* Memory: 8GB RAM
 * Storage: 20GB available space SSD
 * Internet: Broadband connection
 
@@ -31,7 +31,7 @@ These specifications must be met in order to successfully run the Prysm client.
 These hardware specifications are recommended, but not required to run the Prysm client.
 
 * Processor: Intel Core i7–4770 or AMD FX-8310 or better
-* Memory: 8GB RAM
+* Memory: 16GB RAM
 * Storage: 100GB available space SSD
 * Internet: Broadband connection
 

--- a/website/docs/install/install-with-script.md
+++ b/website/docs/install/install-with-script.md
@@ -16,7 +16,7 @@ These specifications must be met in order to successfully run the Prysm client.
 
 * Operating System: 64-bit Linux, Mac OS X 10.14+, Windows 64-bit
 * Processor: Intel Core i5–760 or AMD FX-8100 or better
-* Memory: 4GB RAM
+* Memory: 8GB RAM
 * Storage: 20GB available space SSD
 * Internet: Broadband connection
 
@@ -25,7 +25,7 @@ These specifications must be met in order to successfully run the Prysm client.
 These hardware specifications are recommended, but not required to run the Prysm client.
 
 * Processor: Intel Core i7–4770 or AMD FX-8310 or better
-* Memory: 8GB RAM
+* Memory: 16GB RAM
 * Storage: 100GB available space SSD
 * Internet: Broadband connection
 


### PR DESCRIPTION
In light of the difficulties nodes face during the current low participation in the Medalla testnet, we have opted for increasing our recommended RAM to 16GB and a minimum of 8Gb for nodes