### PR TITLE
Minor spelling correction in beacon-node doc

### DIFF
--- a/website/docs/how-prysm-works/beacon-node.md
+++ b/website/docs/how-prysm-works/beacon-node.md
@@ -4,7 +4,7 @@ title: Prysm's beacon node
 sidebar_label: Beacon node
 ---
 
-The beacon-chain node shipped with Prysm is the keystone component of the Ethereum 2.0 protocol. It is responsibile for running a full [Proof-of-Stake](/docs/terminology#proof-of-stake-pos) blockchain, known as a beacon chain, which uses distributed consensus to agree on blocks both [proposed](/docs/terminology#propose) and [attested](/docs/terminology#attest) on by [validators](/docs/terminology#validator) in the network. Beacon nodes communicate their processed blocks to their peers via a P2P \(peer-to-peer\) network, which also manages the lifecycle process of active [validator clients](/docs/how-prysm-works/prysm-validator-client).
+The beacon-chain node shipped with Prysm is the keystone component of the Ethereum 2.0 protocol. It is responsible for running a full [Proof-of-Stake](/docs/terminology#proof-of-stake-pos) blockchain, known as a beacon chain, which uses distributed consensus to agree on blocks both [proposed](/docs/terminology#propose) and [attested](/docs/terminology#attest) on by [validators](/docs/terminology#validator) in the network. Beacon nodes communicate their processed blocks to their peers via a P2P \(peer-to-peer\) network, which also manages the lifecycle process of active [validator clients](/docs/how-prysm-works/prysm-validator-client).
 
 ![Beacon node](/img/prysm-beacon-chain.png)
 


### PR DESCRIPTION
Minor spelling correction found in the beacon-node documentation.  responsibile -> responsible