### PR TITLE
Fixes parameters in bazel instructions

### DIFF
--- a/website/docs/mainnet/joining-eth2.md
+++ b/website/docs/mainnet/joining-eth2.md
@@ -68,7 +68,7 @@ Where <YOUR_ETH1_NODE_ENDPOINT> is in the format of an http endpoint such as `ht
 **Using Bazel**
 
 ```text
-bazel run //beacon-chain --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT>
+bazel run //beacon-chain -- --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT>
 ```
 
 Where <YOUR_ETH1_NODE_ENDPOINT> is in the format of an http endpoint such as `http://host:port` (ex: `http://localhost:8545` for geth) or an IPC path such as `/path/to/geth.ipc`
@@ -127,7 +127,7 @@ Where <YOUR_ETH1_NODE_ENDPOINT> is in the format of an http endpoint such as `ht
 **Using Bazel**
 
 ```text
-bazel run //beacon-chain --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT>
+bazel run //beacon-chain -- --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT>
 ```
 
 Where <YOUR_ETH1_NODE_ENDPOINT> is in the format of an http endpoint such as `http://host:port` (ex: `http://localhost:8545` for geth) or an IPC path such as `/path/to/geth.ipc`.
@@ -146,7 +146,7 @@ Where <YOUR_ETH1_NODE_ENDPOINT> is in the format of an http endpoint such as `ht
 **Using Bazel**
 
 ```text
-bazel run //beacon-chain --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT>
+bazel run //beacon-chain -- --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT>
 ```
 
 Where <YOUR_ETH1_NODE_ENDPOINT> is in the format of an http endpoint such as `http://host:port` (ex: `http://localhost:8545` for geth) or an IPC path such as `/path/to/geth.ipc`.

--- a/website/docs/prysm-usage/web-interface.md
+++ b/website/docs/prysm-usage/web-interface.md
@@ -105,7 +105,7 @@ bazel run //validator -- --web
 **Using Bazel**
 
 ```text
-bazel run //validator --web
+bazel run //validator -- --web
 ```
 
 </TabItem>

--- a/website/docs/testnet/medalla.md
+++ b/website/docs/testnet/medalla.md
@@ -68,7 +68,7 @@ Where <YOUR_ETH1_NODE_ENDPOINT> is in the format of an http endpoint such as `ht
 **Using Bazel**
 
 ```text
-bazel run //beacon-chain --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT> --medalla
+bazel run //beacon-chain -- --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT> --medalla
 ```
 
 Where <YOUR_ETH1_NODE_ENDPOINT> is in the format of an http endpoint such as `http://host:port` (ex: `http://localhost:8545` for geth) or an IPC path such as `/path/to/geth.ipc`
@@ -128,7 +128,7 @@ Where <YOUR_ETH1_NODE_ENDPOINT> is in the format of an http endpoint such as `ht
 **Using Bazel**
 
 ```text
-bazel run //beacon-chain --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT> --medalla
+bazel run //beacon-chain -- --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT> --medalla
 ```
 
 Where <YOUR_ETH1_NODE_ENDPOINT> is in the format of an http endpoint such as `http://host:port` (ex: `http://localhost:8545` for geth) or an IPC path such as `/path/to/geth.ipc`.
@@ -147,7 +147,7 @@ Where <YOUR_ETH1_NODE_ENDPOINT> is in the format of an http endpoint such as `ht
 **Using Bazel**
 
 ```text
-bazel run //beacon-chain --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT> --medalla
+bazel run //beacon-chain -- --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT> --medalla
 ```
 
 Where <YOUR_ETH1_NODE_ENDPOINT> is in the format of an http endpoint such as `http://host:port` (ex: `http://localhost:8545` for geth) or an IPC path such as `/path/to/geth.ipc`.


### PR DESCRIPTION
Currently several bazel instructions for running Prysm result in an error related to an unrecognized parameter, as the `--` terminator is not correctly included in all cases. This PR should fix that. 