### PR TITLE
Add all missing validator and slasher flags to docs

### DIFF
--- a/website/docs/prysm-usage/parameters.md
+++ b/website/docs/prysm-usage/parameters.md
@@ -126,16 +126,58 @@ These flags are specific to launching the beacon node.
 
 ## Validator parameters
 These flags are specific to launching a validator client.
-### Base flags
+### Management flags
 | Flag          | Usage         |
 | ------------- |:-------------|
-|`--no-custom-config` | Run the beacon chain with the real parameters from phase 0.
-|`--beacon-rpc-provider` | Beacon node RPC provider endpoint. Default: localhost:4000
-|`--tls-cert` | Certificate for secure gRPC. Pass this and the tls-key flag in order to use gRPC securely.
-|`--disable-rewards-penalties-logging` | Disable reward/penalty logging during cluster deployment.
+|`--monitoring-port` | Port used to listening and respond metrics for prometheus. (Default: 8081)
 |`--graffiti` | A string to include in proposed block.
+|`--web` | Enables the web portal for the validator client (work in progress).
+|`--disable-rewards-penalties-logging` | Disable reward/penalty logging during cluster deployment.
 |`--grpc-max-msg-size`| Integer to define max recieve message call size. Default: 52428800 (for 50Mb).
 |`--disable-account-metrics` | Disable prometheus metrics for validator accounts.
+
+### RPC flags 
+| Flag          | Usage         |
+| ------------- |:-------------|
+|`--beacon-rpc-provider` | Beacon node RPC provider endpoint. Default: localhost:4000
+|`--beacon-rpc-gateway-provider` | Beacon node RPC gateway provider endpoint. (Default: localhost:3500)
+|`--slasher-rpc-provider`| Slasher node RPC provider endpoint. Default: 127.0.0.1:4002
+|`--slasher-tls-cert`| Certificate for secure slasher gRPC. Pass this and the tls-key flag in order to use gRPC securely.
+|`--tls-cert` | Certificate for secure gRPC. Pass this and the tls-key flag in order to use gRPC securely.
+|`--rpc`| Enables the RPC server for the validator client (without Web UI).
+|`--rpc-host`| Host on which the RPC server should listen (default: "127.0.0.1")
+|`--rpc-port`| RPC port exposed by a validator client (default: 7000)
+|`--grpc-gateway-port`| Enable gRPC gateway for JSON requests (default: 7500)
+|`--grpc-gateway-host`| The host on which the gateway server runs on (default: 127.0.0.1)
+|`--grpc-retries`| Number of attempts to retry gRPC requests (default: 5)
+|`--grpc-retry-delay`| The amount of time between gRPC retry requests. (default: 1s)
+|`--grpc-headers`| A comma separated list of key value pairs to pass as gRPC headers for all gRPC calls. Example: --grpc-headers=key=value
+|`--grpc-gateway-corsdomain`| Comma separated list of domains from which to accept cross origin requests (browser enforced). This flag has no effect if not used with --grpc-gateway-port. (default: "http://localhost:4242,http://127.0.0.1:4242,http://localhost:4200,http://0.0.0.0:4242,http://0.0.0.0:4200")
+
+
+### Accounts flags
+| Flag          | Usage         |
+| ------------- |:-------------|
+|`--wallet-dir`| Path to a wallet directory on-disk for Prysm validator accounts.
+|`--wallet-password-file`| Path to a plain-text, .txt file containing your wallet password.
+|`--keys-dir`| Path to a directory where keystores to be imported are stored.
+|`--backup-dir`| Path to a directory where accounts will be backed up into a zip file.
+|`--num-accounts`| Number of accounts to generate for derived wallets (default: 1).
+|`--account-password-file`| Path to a plain-text, .txt file containing a password for a validator account.
+|`--backup-password-file`| Path to a plain-text, .txt file containing the desired password for your backed up accounts.
+|`--mnemonic-file`| File to retrieve mnemonic for non-interactively passing a mnemonic phrase into wallet recover.
+|`--mnemonic-25th-word-file`| (Advanced) Path to a plain-text, .txt file containing a 25th word passphrase for your mnemonic for HD wallets.
+|`--skip-mnemonic-25th-word-check`| Allows for skipping the check for a mnemonic 25th word passphrase for HD wallets.
+|`--import-private-key-file`| Path to a plain-text, .txt file containing a hex string representation of a private key to import.
+|`--keymanager-kind`| Kind of keymanager, either imported, derived, or remote, specified during wallet creation.
+|`--delete-public-keys`| Comma-separated list of public key hex strings to specify which validator accounts to delete.
+|`--disable-public-keys`| Comma-separated list of public key hex strings to specify which validator accounts to disable.
+|`--enable-public-keys`| Comma-separated list of public key hex strings to specify which validator accounts to enable.
+|`--backup-public-keys`| Comma-separated list of public key hex strings to specify which validator accounts to backup.
+|`--public-keys`| Comma-separated list of public key hex strings to specify on which validator accounts to perform a voluntary exit.
+|`--show-deposit-data`| Display raw eth1 tx deposit data for validator accounts.
+|`--show-private-keys`| Display the private keys for validator accounts.
+|`--skip-deposit-confirmation`| Skips the y/n confirmation prompt for sending a deposit to the deposit contract.
 
 ### Interop flags
 | Flag          | Usage         |
@@ -148,14 +190,18 @@ These flags are specific to launching a slasher client.
 ### Base flags
 | Flag          | Usage         |
 | ------------- |:-------------|
-|`--beacon-rpc-provider` | Specify the beacon node RPC provider endpoint Default: "localhost:4000"
-|`--beacon-tls-cert` | Provide the certificate for secure beacon gRPC connection. Pass this in order to use beacon gRPC securely.
-|`--rebuild-span-maps` | Rebuild span maps from indexed attestations in db Default: false
-|`--rpc-port` | Specify the RPC port exposed by the slasher Default: 5000
-|`--tls-cert` | Specify the certificate to use for secure gRPC. Pass this and the tls-key flag in order to use gRPC securely.
-|`--tls-key` | Specify the private key for secure gRPC. Pass this and the tls-cert flag in order to use gRPC securely.
+|`--beacon-tls-cert`| Certificate for secure beacon gRPC connection. Pass this in order to use beacon gRPC securely.
+|`--beacon-rpc-provider`| Beacon node RPC provider endpoint (default: localhost:4000)
+|`--enable-historical-detection`| Enables historical attestation detection for the slasher. Requires --historical-slasher-node on the beacon node.
+|`--spans-cache-size`| Sets the span cache size. (default: 1500)
+|`--highest-att-cache-size`| Sets the highest attestation cache size. (default: 3000)
+|`--tls-cert`| Certificate for secure gRPC. Pass this and the tls-key flag in order to use gRPC securely.
+|`--tls-key`| Key for secure gRPC. Pass this and the tls-cert flag in order to use gRPC securely.
+|`--monitoring-port`| Port used to listening and respond metrics for prometheus. (default: 8082)
+|`--rpc-host`| Host on which the RPC server should listen. (default: "127.0.0.1")
+|`--rpc-port`| RPC port exposed by the slasher. (default: 4002)
 
-### Debug flags
+## General debug flags
 | Flag          | Usage         |
 | ------------- |:-------------|
 |`--cpuprofile` | Write CPU profile to the given file


### PR DESCRIPTION
This PR adds all the flags we've had missing on our documentation for the validator and slasher clients. Mostly focusing around accounts management for the validator. 