### PR TITLE
Update exposing the beacon port

### DIFF
--- a/website/docs/prysm-usage/web-interface.md
+++ b/website/docs/prysm-usage/web-interface.md
@@ -79,10 +79,10 @@ The available parameters to customize are:
 If you are running your beacon node and validator on some server that you want to access from the outside, we recommend SSH local port forwarding to access it. For example, you would do the following from your home computer:
 
 ```
-ssh -L 7500:127.0.0.1:7500 user@host_ip
+ssh -L 7500:127.0.0.1:7500 -L 3500:127.0.0.1:3500 user@host_ip
 ```
 
-where you replace `user@host_ip` with the user and host ip address of the remote machine you are trying to access. This will forward all requests from your home computer's localhost:7500 to the remote instance's localhost:7500, allowing you to visit `http://localhost:7500` from your favorite browser and then access the validator web interface! This is the safest approach to access it, as you are exposing the web interface to the open Internet.
+where you replace `user@host_ip` with the user and host ip address of the remote machine you are trying to access. This will forward all requests from your home computer's localhost:7500 to the remote instance's localhost:7500, allowing you to visit `http://localhost:7500` from your favorite browser and then access the validator web interface! This is the safest approach to access it, as you are exposing the web interface to the open Internet. The beacon port 3500 is needed as well to get the data for the webui.
 
 ## Step 4: Monitor your beacon node and validator client logs, accounts, and more
 

--- a/website/docs/prysm-usage/web-interface.md
+++ b/website/docs/prysm-usage/web-interface.md
@@ -79,10 +79,10 @@ The available parameters to customize are:
 If you are running your beacon node and validator on some server that you want to access from the outside, we recommend SSH local port forwarding to access it. For example, you would do the following from your home computer:
 
 ```
-ssh -L 7500:127.0.0.1:7500 -L 3500:127.0.0.1:3500 user@host_ip
+ssh -L 7500:127.0.0.1:7500 -L 3500:127.0.0.1:3500 -L 8080:127.0.0.1:8080 -L 8081:127.0.0.1:8081 user@host_ip
 ```
 
-where you replace `user@host_ip` with the user and host ip address of the remote machine you are trying to access. This will forward all requests from your home computer's localhost:7500 to the remote instance's localhost:7500, allowing you to visit `http://localhost:7500` from your favorite browser and then access the validator web interface! This is the safest approach to access it, as you are exposing the web interface to the open Internet. The beacon port 3500 is needed as well to get the data for the webui.
+where you replace `user@host_ip` with the user and host ip address of the remote machine you are trying to access. This will forward all requests from your home computer's localhost:7500 to the remote instance's localhost:7500, allowing you to visit `http://localhost:7500` from your favorite browser and then access the validator web interface! This is the safest approach to access it, as you are exposing the web interface to the open Internet. The beacon port 3500 and the websocket port 8080/8081 are needed as well to get the data for the webui and logs.
 
 ## Step 4: Monitor your beacon node and validator client logs, accounts, and more
 


### PR DESCRIPTION
SSH Local Port Forwarding requires the 3500 port to get the beacon data otherwise it will fail.