### PR TITLE
Update Documentation Popular Requests

### DIFF
--- a/website/docs/how-prysm-works/ethereum-2.0-public-api.md
+++ b/website/docs/how-prysm-works/ethereum-2.0-public-api.md
@@ -1,19 +1,36 @@
 ---
 id: ethereum-2-public-api
 title: Ethereum 2.0 public API
-sidebar_label: Eth2 public API
+sidebar_label: Beacon node API 
 description: This section contains service definitions and gRPC instructions to interact with the public API.
 ---
 
-Browse our API documentation for ETH2 [https://api.prylabs.network](https://api.prylabs.network)!
+:::info Our API documentation website is undergoing maintenance
+Our API documentation website [https://api.prylabs.network](https://api.prylabs.network) is currently down due to maintenance. In the meantime, you can browse our API schema here: [github.com/prysmaticlabs/ethereumapis](https://github.com/prysmaticlabs/ethereumapis/tree/master/eth/v1alpha1). Our current API version used in Prysm is `v1alpha1`. 
+:::
 
-One of the required components nodes in the Ethereum 2.0 network is to expose an API server for outside interaction. This API is critical for running validators on eth2, as validator clients can connect to nodes and query their API to figure out their assigned duties, to submit block proposals, and more. Prysm's eth2 API schema is maintained in its unique repository: [github.com/prysmaticlabs/ethereumapis](https://github.com/prysmaticlabs/ethereumapis) and is implemented by Prysm beacon nodes [here](https://github.com/prysmaticlabs/prysm/blob/master/beacon-chain/rpc/service.go). 
+One of the required components nodes in the Ethereum 2.0 network is to expose an API server for outside interaction. This API is critical for running validators on eth2, as validator clients can connect to nodes and query their API to figure out their assigned duties, to submit block proposals, and more. Prysm's eth2 API schema is maintained in its unique repository: [github.com/prysmaticlabs/ethereumapis](https://github.com/prysmaticlabs/ethereumapis) and is implemented by Prysm beacon nodes [here](https://github.com/prysmaticlabs/prysm/blob/master/beacon-chain/rpc/service.go). Note, this API is **only used by Prysm**. 
+
+
+:::tip Standard API conformance is underway
+There is an effort to standardize an eth2 API for all implementations [here](https://github.com/ethereum/eth2.0-apis), and we are currently working on implementing it into Prysm. In the meantime, `ethereumapis` is the only supported API schema by Prysm.
+:::
 
 ![gRPC](/img/grpc-logo2.png)
 
-Prysm implements its API by using the popular [gRPC](https://grpc.io) project created by Google, providing highly advanced functionality for eth2. Interacting with the API requires the use of protocol buffers, also known as protobuf. These [protocol buffer](https://developers.google.com/protocol-buffers/) service definitions support both [gRPC](https://grpc.io/) as well as JSON over HTTP.  For information on the functionality of gRPC and protocol buffers more generally, see the [gRPC guide](https://grpc.io/docs/guides/).
+Prysm implements its API by using the popular [gRPC](https://grpc.io) project created by Google, providing highly advanced functionality for eth2. Interacting with the API requires the use of protocol buffers, also known as protobuf. These [protocol buffer](https://developers.google.com/protocol-buffers/). For information on the functionality of gRPC and protocol buffers more generally, see the [gRPC guide](https://grpc.io/docs/guides/).
 
-## Service definitions
+## Calling the API on your local beacon node
+
+By default, the beacon node exposes a [gRPC](https://grpc.io) API on host `127.0.0.1:4000`, which is accessed by the validator client. This is not an HTTP endpoint, so you will not be able to perform API queries via HTTP on that port. However, we also expose a JSON-HTTP endpoint on `127.0.0.1:3500` by default for your needs. If you want to query information such as the chainhead from your local beacon node, you can call:
+
+```
+http://127.0.0.1:3500/eth/v1alpha1/beacon/chainhead
+```
+
+All our service definitions are explained below:
+
+### Service definitions
 
 | Package | Service | Version | Description |
 | :--- | :--- | :--- | :--- |

--- a/website/docs/prysm-usage/database-backups.md
+++ b/website/docs/prysm-usage/database-backups.md
@@ -1,0 +1,179 @@
+---
+id: database-backups
+title: Performing database backups for your node and validator
+sidebar_label: Database backups
+---
+
+This section outlines how to perform database backups for your beacon node and validator client. Both services expose an **HTTP backup endpoint** which is the **safest way** to trigger a database backup.
+
+:::danger Doing manual folder backups is not safe
+If you perform backups by manually copying the validator database while the client is running, you risk copying a corrupted database! You might be copying the folder right when the validator is in the middle of writing data to the database, and could end up with a bad backup. For this reason, HTTP backups are the way to go.
+:::
+
+## Beacon node
+
+Both the beacon node and validator use an embedded key-value store as a database called [BoltDB](https://github.com/boltdb/bolt) to store all important information. Backing up your beacon node database is a good practice, although **not critical** to being able to validate in eth2. if you want to perform a backup, here's the safest way to do it.
+
+### Add the backup webhook flags to your beacon node
+
+Add the following flags to your beacon node:
+
+- `--enable-db-backup-webhook`: Serve an http server to initiate database backups. The handler is served on the beacon node's monitoring host and port. Default endpoint is `http://127.0.0.1:8080/db/backup` if the flag is enabled.
+- `db-backup-output-dir`: Folder path to where backups will be output to, such as `/path/to/mybackups`.
+
+Now, your beacon node will expose an HTTP endpoint `http://monitoringhost:monitoringport/db/backup`, which is `http://127.0.0.1:8080/db/backup` by default. You can hit this endpoint using curl or any other tool you prefer, and a backup will initiate which will be output to your `--db-backup-output-dir` path.
+
+### Restoring from a backup
+
+Ensure your beacon node is turned off if restoring a backup. You can restore a beacon chain DB from a backup file with the following command:
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs
+  groupId="operating-systems"
+  defaultValue="lin"
+  values={[
+    {label: 'Linux', value: 'lin'},
+    {label: 'Windows', value: 'win'},
+    {label: 'MacOS', value: 'mac'},
+    {label: 'Arm64', value: 'arm'},
+  ]
+}>
+<TabItem value="lin">
+
+**Using the Prysm installation script**
+
+```sh
+prysm.sh beacon-chain db restore --restore-source-file=/path/to/backup --restore-target-dir=/path/to/desired/datadir
+```
+
+**Using Bazel**
+
+```sh
+bazel run //beacon-chain -- db restore --restore-source-file=/path/to/backup --restore-target-dir=/path/to/desired/datadir
+```
+
+</TabItem>
+<TabItem value="win">
+
+**Using the Prysm installation script**
+
+```sh
+prysm.bat beacon-chain db restore --restore-source-file=\path\to\backup --restore-target-dir=\path\to\desired\datadir
+```
+
+</TabItem>
+<TabItem value="mac">
+
+**Using the Prysm installation script**
+
+```sh
+prysm.sh beacon-chain db restore --restore-source-file=/path/to/backup --restore-target-dir=/path/to/desired/datadir
+```
+
+**Using Bazel**
+
+```sh
+bazel run //beacon-chain -- db restore --restore-source-file=/path/to/backup --restore-target-dir=/path/to/desired/datadir
+```
+
+</TabItem>
+<TabItem value="arm">
+
+**Using the Prysm installation script**
+
+```sh
+prysm.sh beacon-chain db restore --restore-source-file=/path/to/backup --restore-target-dir=/path/to/desired/datadir
+```
+
+**Using Bazel**
+
+```sh
+bazel run //beacon-chain -- db restore --restore-source-file=/path/to/backup --restore-target-dir=/path/to/desired/datadir
+```
+
+</TabItem>
+</Tabs>
+
+## Validator client
+
+### Add the backup webhook flags to your validator client 
+
+Add the following flags to your validator client:
+
+- `--enable-db-backup-webhook`: Serve an http server to initiate database backups. The handler is served on the validator client's monitoring host and port. Default endpoint is `http://127.0.0.1:8081/db/backup` if the flag is enabled.
+- `db-backup-output-dir`: Folder path to where backups will be output to, such as `/path/to/mybackups`.
+
+Now, your validator client will expose an HTTP endpoint `http://monitoringhost:monitoringport/db/backup`, which is `http://127.0.0.1:8081/db/backup` by default. You can hit this endpoint using curl or any other tool you prefer, and a backup will initiate which will be output to your `--db-backup-output-dir` path.
+
+
+### Restoring from a backup
+
+Ensure your validator client is turned off if restoring a backup. You can restore a validator DB from a backup file with the following command:
+
+<Tabs
+  groupId="operating-systems"
+  defaultValue="lin"
+  values={[
+    {label: 'Linux', value: 'lin'},
+    {label: 'Windows', value: 'win'},
+    {label: 'MacOS', value: 'mac'},
+    {label: 'Arm64', value: 'arm'},
+  ]
+}>
+<TabItem value="lin">
+
+**Using the Prysm installation script**
+
+```sh
+prysm.sh validator db restore --restore-source-file=/path/to/backup --restore-target-dir=/path/to/desired/datadir
+```
+
+**Using Bazel**
+
+```sh
+bazel run //validator -- db restore --restore-source-file=/path/to/backup --restore-target-dir=/path/to/desired/datadir
+```
+
+</TabItem>
+<TabItem value="win">
+
+**Using the Prysm installation script**
+
+```sh
+prysm.bat validator db restore --restore-source-file=\path\to\backup --restore-target-dir=\path\to\desired\datadir
+```
+
+</TabItem>
+<TabItem value="mac">
+
+**Using the Prysm installation script**
+
+```sh
+prysm.sh validator db restore --restore-source-file=/path/to/backup --restore-target-dir=/path/to/desired/datadir
+```
+
+**Using Bazel**
+
+```sh
+bazel run //validator -- db restore --restore-source-file=/path/to/backup --restore-target-dir=/path/to/desired/datadir
+```
+
+</TabItem>
+<TabItem value="arm">
+
+**Using the Prysm installation script**
+
+```sh
+prysm.sh validator db restore --restore-source-file=/path/to/backup --restore-target-dir=/path/to/desired/datadir
+```
+
+**Using Bazel**
+
+```sh
+bazel run //validator -- db restore --restore-source-file=/path/to/backup --restore-target-dir=/path/to/desired/datadir
+```
+
+</TabItem>
+</Tabs>

--- a/website/docs/prysm-usage/eth1-nodes.md
+++ b/website/docs/prysm-usage/eth1-nodes.md
@@ -57,13 +57,13 @@ In case your eth1 node unexpectedly goes down, you can specify a list of fallbac
 #### Using regular flags
 
 ```
---http-web3provider=<YOUR MAIN ETH1 ENDPOINT> --fallback-web3provider=<PROVIDER 1>,<PROVIDER 2>
+--http-web3provider=<YOUR MAIN ETH1 ENDPOINT> --fallback-web3provider=<PROVIDER 1> --fallback-web3provider=<PROVIDER 2>
 ```
 
-You can specify your main provider and then a comma-separated list of --fallback-web3provider. Here's what a real setup could look like:
+You can specify your main provider and as many --fallback-web3provider as you need. Here's what a real setup could look like:
 
 ```
---http-web3provider=http://localhost:8545 --fallback-web3provider=https://mainnet.infura.io/v3/YOUR-PROJECT-ID,https://eth-mainnet.alchemyapi.io/v2/YOUR-PROJECT-ID
+--http-web3provider=http://localhost:8545 --fallback-web3provider=https://mainnet.infura.io/v3/YOUR-PROJECT-ID --fallback-web3provider=https://eth-mainnet.alchemyapi.io/v2/YOUR-PROJECT-ID
 ```
 
 Where your main provider is your local go-ethereum node running on port 8545, then you can fallback to infura or alchemy as needed.

--- a/website/docs/prysm-usage/eth1-nodes.md
+++ b/website/docs/prysm-usage/eth1-nodes.md
@@ -49,3 +49,36 @@ then connect to your eth1 node with:
 ```text
 ./prysm.sh beacon-chain --http-web3provider=$HOME/Mainnet/geth.ipc
 ```
+
+## Adding fallback eth1 nodes
+
+In case your eth1 node unexpectedly goes down, you can specify a list of fallback eth1 nodes that your beacon node can always reach out to. To use this functionality, you can add the following flag to the beacon node:
+
+#### Using regular flags
+
+```
+--http-web3provider=<YOUR MAIN ETH1 ENDPOINT> --fallback-web3provider=<PROVIDER 1>,<PROVIDER 2>
+```
+
+You can specify your main provider and then a comma-separated list of --fallback-web3provider. Here's what a real setup could look like:
+
+```
+--http-web3provider=http://localhost:8545 --fallback-web3provider=https://mainnet.infura.io/v3/YOUR-PROJECT-ID,https://eth-mainnet.alchemyapi.io/v2/YOUR-PROJECT-ID
+```
+
+Where your main provider is your local go-ethereum node running on port 8545, then you can fallback to infura or alchemy as needed.
+
+:::tip Prysm will automatically use your main provider always
+In case your main provider comes back from the dead, Prysm will detect that and switch over to it for primary usage automatically. This will save you any costs on your fallback providers.
+:::
+
+#### Using a config file
+
+If you are running Prysm and specifying command line flags via a config.yaml file, you can do the following:
+
+```yaml
+http-web3provider: http://localhost:8545
+fallback-web3provider:
+- https://mainnet.infura.io/v3/YOUR-PROJECT-ID
+- https://eth-mainnet.alchemyapi.io/v2/YOUR-PROJECT-ID
+```

--- a/website/docs/prysm-usage/staying-up-to-date.md
+++ b/website/docs/prysm-usage/staying-up-to-date.md
@@ -32,6 +32,12 @@ Prysm has two official channels for release updates: our [Discord](https://disco
 
 ## How to securely update Prysm
 
+Updating in Prysm can incur a few seconds downtime depending on your installation method. Every validator will attest once per epoch (every 6.4 minutes on average), while proposals are more rare. To check your next assigned slot to attest or propose, we recommend checking your validator on [beaconcha.in](https://beaconcha.in). Although missing a single validator duty is not a big deal, you can wait to update right after you attest or propose for optimal performance.
+
+:::tip Missing a single validator duty is not a big deal
+Missing a single duty is really not a big deal for your validator profitability. Unless you want to be at the top of the [leaderboard](https://beaconcha.in/validators/leaderboard), do not worry too much. You will be profitable again in no time once your validator is up next epoch.
+:::
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -21,6 +21,7 @@
 			"prysm-usage/setup-eth1",
 			"prysm-usage/graffiti-file",
 			"prysm-usage/p2p-host-ip",
+			"prysm-usage/database-backups",
 			"prysm-usage/is-everything-fine",
 			"prysm-usage/web-interface",
 			"prysm-usage/secure-grpc",

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -39,6 +39,8 @@
 			"wallet/ethdo"
 		],
 
+		"ETH2 API": 	["how-prysm-works/ethereum-2-public-api"],
+
 		"How Prysm works": 	[	"how-prysm-works/architecture-overview",
 								"how-prysm-works/beacon-node",
 								"how-prysm-works/prysm-validator-client",
@@ -51,7 +53,6 @@
 
 		"Developer tools": 	["devtools/block-explorers"],
 
-		"Public API": 	["how-prysm-works/ethereum-2-public-api"],
 
 		"Contribute": [	
 			"contribute/doc-standards",


### PR DESCRIPTION
This PR adds the following highly requested documentation:
- [x] Information on to check if a validator is performing duties before updating Prysm
- [x] Information on the latest status of api.prylabs.network, eth2apis, and how to access the API on your local beaocn node
- [x] Dedicated page for how to perform DB backups for the beacon node and validator and how to restore from backups
- [x] Section on how to use fallback eth1 providers with examples for the beacon node