### PR TITLE
Add Monitoring Host to Params

### DIFF
--- a/website/docs/prysm-usage/monitoring/grafana-dashboard.md
+++ b/website/docs/prysm-usage/monitoring/grafana-dashboard.md
@@ -15,6 +15,8 @@ sidebar_label: Monitoring with Grafana
   * Validator metrics are found at http://localhost:8081/metrics
   * Slasher metrics are found at http://localhost:8082/metrics 
 
+If you are using a custom --monitoring-host for these processes, such as an IP address, then just change `localhost` to the custom host you are using. 
+
 > Note: Running a slasher isn't mandatory for staking, only people that are running a slasher can find the metrics at the port 8082. For those that don't run a slasher, all instructions that follow remain correct.
 
 ## Installing Prometheus

--- a/website/docs/prysm-usage/parameters.md
+++ b/website/docs/prysm-usage/parameters.md
@@ -154,6 +154,7 @@ These flags are specific to launching a validator client.
 |`--tls-cert` | Certificate for secure gRPC. Pass this and the tls-key flag in order to use gRPC securely.
 |`--graffiti` | A string to include in proposed block.
 |`--web` | Enables the web portal for the validator client (work in progress).
+|`--monitoring-host` | Host used to listening and respond metrics for prometheus. (Default: 127.0.0.1)
 |`--monitoring-port` | Port used to listening and respond metrics for prometheus. (Default: 8081)
 |`--grpc-max-msg-size`| Integer to define max recieve message call size. Default: 52428800 (for 50Mb).
 |`--disable-rewards-penalties-logging` | Disable reward/penalty logging during cluster deployment.
@@ -220,6 +221,7 @@ These flags are specific to launching a slasher client.
 |`--highest-att-cache-size`| Sets the highest attestation cache size. (default: 3000)
 |`--tls-cert`| Certificate for secure gRPC. Pass this and the tls-key flag in order to use gRPC securely.
 |`--tls-key`| Key for secure gRPC. Pass this and the tls-cert flag in order to use gRPC securely.
+|`--monitoring-host` | Host used to listening and respond metrics for prometheus. (Default: 127.0.0.1)
 |`--monitoring-port`| Port used to listening and respond metrics for prometheus. (default: 8082)
 |`--rpc-host`| Host on which the RPC server should listen. (default: "127.0.0.1")
 |`--rpc-port`| RPC port exposed by the slasher. (default: 4002)


### PR DESCRIPTION
Adds the monitoring host option to our documentation params, fixes #218