### PR TITLE
Add Open Source Mirrors of Beaconcha.in

### DIFF
--- a/website/docs/devtools/block-explorers.md
+++ b/website/docs/devtools/block-explorers.md
@@ -22,9 +22,8 @@ beaconcha.in is a beacon chain explorer maintained by [Bitfly](https://www.bitfl
 
 This sections lists open source mirrors of forks of original, major block explorers. [Redot](https://redot.com) maintains two open-source mirrors that are forks of Bitfly's original work [beaconcha.in](https://beaconcha.in) at
 
-[ethscan.org](https://ethscan.org)
-and
-[eth2.redot.com](https://eth2.redot.com)
+- [ethscan.org](https://ethscan.org)
+- [eth2.redot.com](https://eth2.redot.com)
 
 Their respective Github repositories are:
 

--- a/website/docs/devtools/block-explorers.md
+++ b/website/docs/devtools/block-explorers.md
@@ -28,6 +28,6 @@ and
 
 Their respective Github repositories are:
 
-[nobd/ethscan-org](https://github.com/nobd/ethscan-org)
-[eth2-redot-com](https://github.com/AtlantPlatform/eth2-redot-com)
+- [nobd/ethscan-org](https://github.com/nobd/ethscan-org)
+- [eth2-redot-com](https://github.com/AtlantPlatform/eth2-redot-com)
 

--- a/website/docs/devtools/block-explorers.md
+++ b/website/docs/devtools/block-explorers.md
@@ -17,3 +17,17 @@ eth2stats.io is a beacon chain explorer maintained by [Alethio](https://aleth.io
 ## [beaconcha.in](https://beaconcha.in/)
 
 beaconcha.in is a beacon chain explorer maintained by [Bitfly](https://www.bitfly.at).
+
+## Mirrors and Forks
+
+This sections lists open source mirrors of forks of original, major block explorers. [Redot](https://redot.com) maintains two open-source mirrors that are forks of Bitfly's original work [beaconcha.in](https://beaconcha.in) at
+
+[ethscan.org](https://ethscan.org)
+and
+[eth2.redot.com](https://eth2.redot.com)
+
+Their respective Github repositories are:
+
+[nobd/ethscan-org](https://github.com/nobd/ethscan-org)
+[eth2-redot-com](https://github.com/AtlantPlatform/eth2-redot-com)
+


### PR DESCRIPTION
This PR is an alternative to #308 which specifically lists mirrors of original block explorers under their own section. Now that Redot fulfilled all the requirements of proper attribution, there is no reason for us to not list open source mirrors in our documentation portal.