### PR TITLE
Add `Ordered` description to graffiti-file

### DIFF
--- a/website/docs/prysm-usage/graffiti-file.md
+++ b/website/docs/prysm-usage/graffiti-file.md
@@ -18,11 +18,12 @@ The validator flag: `--graffiti-file=/path/to/graffitis.yaml`
 
 It supports yaml and the following scalar and collections. We will go through each of them in detail below.
  * Specific
+ * Ordered
  * Random
  * Default
 
 ### Specific usage
-Specific chooses the graffiti based on the validator ID. When validator ID is not specified, a graffiti will be chosen from the `random` list. This takes precedent over random and default. 
+Specific chooses the graffiti based on the validator ID. When validator ID is not specified, a graffiti will be chosen from another list. This takes precedent over ordered, random and default.
 
 **Example**:
 ```yaml=
@@ -39,6 +40,27 @@ default: "Mr F was here"
 ```
 Example output:
 ![image](/img/graffiti-specific.png)
+
+### Ordered
+Ordered chooses each entry of graffiti in order from the list. The validator will start again from the top of the list each time the graffiti file is updated. Once the list is finished, the `random` or `default` graffiti will be used. This takes precedent over both random and default.
+
+**Example**:
+```yaml=
+ordered:
+  - "Mr A was here"
+  - "Mr B was here"
+  - "Mr C was here"
+default: "Mr F was here"
+```
+
+Example output:
+```
+INFO validator: Submitted new block blockRoot=0x00000 graffiti="Mr A was here"
+INFO validator: Submitted new block blockRoot=0x00000 graffiti="Mr B was here"
+INFO validator: Submitted new block blockRoot=0x00000 graffiti="Mr C was here"
+INFO validator: Submitted new block blockRoot=0x00000 graffiti="Mr F was here"
+INFO validator: Submitted new block blockRoot=0x00000 graffiti="Mr F was here"
+```
 
 ### Random
 Random chooses a random graffiti from the list. If `random` is not specified, the `default` graffiti will be used.


### PR DESCRIPTION
This should only be merged once https://github.com/prysmaticlabs/prysm/pull/8482 has been released in the next version.

I was unable to generate the `Example output` image, but perhaps they should all be changed to text only? Alternatively someone else could generate a similar styled image for me.