### PR TITLE
minor: use go 1.16 in contribution guidelines

### DIFF
--- a/website/docs/contribute/contribution-guidelines.md
+++ b/website/docs/contribute/contribution-guidelines.md
@@ -44,7 +44,7 @@ go version go1.16 darwin/amd64
 
 ### Building and testing Prysm with Go
 
-The Prysm project is a large monorepo containing all sorts of tools and services that implement the eth2 protocol. We use the Go for everything we do in development, helping everyone have reproducible builds. If you want to build the whole project, you can run the following command:
+The Prysm project is a large monorepo containing all sorts of tools and services that implement the eth2 protocol. We use Go for everything we do in development, helping everyone have reproducible builds. If you want to build the whole project, you can run the following command:
 
 ```text
 $ go build -v ./...

--- a/website/docs/contribute/contribution-guidelines.md
+++ b/website/docs/contribute/contribution-guidelines.md
@@ -15,7 +15,7 @@ Once you are a bit more familiar with the concepts behind eth2 and are ready to 
 To develop Prysm, you'll need the following:
 
 - A modern windows, osx, or linux operating system
-- Go 1.14.x version installed, download and install [here](https://golang.org/dl/)
+- Go 1.16.x version installed, download and install [here](https://golang.org/dl/)
 - The `git` package installed
 - A code editor such as [Visual Studio Code](https://code.visualstudio.com/download) or Jetbrains' [Goland IDE](https://www.jetbrains.com/go/) or your preferred one
 
@@ -39,7 +39,7 @@ $ go version
 
 Example output:
 ```text
-go version go1.14.4 darwin/amd64
+go version go1.16 darwin/amd64
 ```
 
 ### Building and testing Prysm with Go


### PR DESCRIPTION
Following current go build instructions will result in logs like
```
slasher/db/testing/setup_db.go:15:30: t.TempDir undefined (type testing.TB has no field or method TempDir)
note: module requires Go 1.16
```