### PR TITLE
Add Bazel Instructions for Docker

### DIFF
--- a/website/docs/install/install-with-bazel.md
+++ b/website/docs/install/install-with-bazel.md
@@ -79,7 +79,7 @@ We do not write our own Dockerfiles, as Bazel provides us a more sandboxed, simp
 
 ### Dependencies needed
 
-* All specified dependencies for building with Bazel [here](docs/install/install-with-bazel#dependencies)
+* All specified dependencies for building with Bazel [here](/docs/install/install-with-bazel#dependencies)
 * Python installed and available in your computer
 
 ### Build process

--- a/website/docs/install/install-with-bazel.md
+++ b/website/docs/install/install-with-bazel.md
@@ -35,7 +35,7 @@ These hardware specifications are recommended, but not required to run the Prysm
 ## Dependencies
 
 * A modern UNIX operating system
-* The latest release of [Bazel](https://docs.bazel.build/versions/master/install.html) installed
+* [Bazel](https://docs.bazel.build/versions/3.7.0/install.html) version **3.7.0** installed (Ensure you are doing 3.7.0)
 * The `cmake` package installed
 * The `git` package installed
 * `libssl-dev` installed
@@ -44,9 +44,9 @@ These hardware specifications are recommended, but not required to run the Prysm
 
 ## Why Bazel?
 
-Instead of using the `Go` tool to build Prysm, our team relies on the [Bazel](https://bazel.build) build system used by major companies to manage monorepositories. Bazel provides reproducible builds and a sandboxed environment that ensures everyone building Prysm has the same experience and can build our entire project from a single command. For more detailed rationale on why Bazel, how it works in Prysm, and all important information about how exactly building from source works, read our rationale [here](/docs/reading/bazel)
+Instead of using the `Go` tool to build Prysm, our team relies on the [Bazel](https://bazel.build) build system used by major companies to manage monorepositories. Bazel provides reproducible builds and a sandboxed environment that ensures everyone building Prysm has the same experience and can build our entire project from a single command. For more detailed rationale on why Bazel, how it works in Prysm, and all important information about how exactly building from source works, read our rationale [here](/docs/reading/bazel).
 
-## Installing Prysm
+## Building Prysm from source
 
 1. Open a terminal window. Ensure you are running the most recent version of Bazel by issuing the command:
 
@@ -70,3 +70,124 @@ bazel build //validator:validator --config=release
 ```
 
 Bazel will automatically pull and install any dependencies as well, including Go and necessary compilers. Now that your installation is done, you can then read [joining eth2](/docs/mainnet/joining-eth2).
+
+## Building Docker images
+
+We use Bazel to build the Docker images for Prysm as well. This section outlines comprehensive instructions on how to build them by yourself, run them in Docker, and push to an image registry if desired. In particular, we use [`bazel rules docker`](https://github.com/bazelbuild/rules_docker) which provides us the ability to specify a base, barebones image, and essentially builds our binary and creates a Docker container as a simple wrapper over our binaries.
+
+We do not write our own Dockerfiles, as Bazel provides us a more sandboxed, simple experience with all of its benefits. To see an example use of `bazel rules docker` for how we build a particular package, see [here](https://github.com/prysmaticlabs/prysm/blob/aa389c82a157008741450ba1e04d898924734432/tools/bootnode/BUILD.bazel#L36). 
+
+### Dependencies needed
+
+* All specified dependencies for building with Bazel [here](docs/install/install-with-bazel#dependencies)
+* Python installed and available in your computer
+
+### Build process
+
+#### Regular Docker images
+
+At the moment, Prysm docker images can only be built on **Linux** operating systems. The standard images are very thin wrappers around the Prysm beacon-chain and validator binaries, and do not contain any other typical components of Docker images such as a bash shell. These are the Docker images we ship to all users, and you can build them yourself as follows:
+
+```bash
+bazel build //beacon-chain:image_bundle --config=release
+bazel build //validator:image_bundle --config=release
+```
+
+The tags for the images are specified [here](https://github.com/prysmaticlabs/prysm/blob/ff329df808ad68fbe79d11c73121fa6a7a0c0f29/cmd/beacon-chain/BUILD.bazel#L58) for the beacon-chain and [here](https://github.com/prysmaticlabs/prysm/blob/ff329df808ad68fbe79d11c73121fa6a7a0c0f29/cmd/validator/BUILD.bazel#L59) for the validator. The default image tags for these images are:
+
+```text
+gcr.io/prysmaticlabs/prysm/beacon-chain:latest
+gcr.io/prysmaticlabs/prysm/validator:latest
+```
+
+You can edit these in the links above to your liking.
+
+#### Alpine images
+
+Prysm also provides Alpine images built using:
+
+```bash
+bazel build //beacon-chain:image_bundle_alpine --config=release
+bazel build //validator:image_bundle_alpine --config=release
+```
+
+#### Debug images
+
+Prysm also provides debug images built using:
+
+```bash
+bazel build //beacon-chain:image_bundle_debug --config=release
+bazel build //validator:image_bundle_debug --config=release
+```
+
+### Running images
+
+You can load the images into your local Docker daemon by first building a `.tar` file as follows for your desired image bundle:
+
+```text
+bazel build cmd/beacon-chain:image_bundle.tar
+bazel build cmd/validator:image_bundle.tar
+```
+
+Then, you can load it into Docker with:
+```text
+docker load -i bazel-bin/my/image/helloworld.tar
+```
+
+For example, you may see output such as this:
+
+```
+docker load -i bazel-bin/cmd/beacon-chain/image_bundle.tar
+fd6fa224ea91: Loading layer [==================================================>]  3.031MB/3.031MB
+87c9f1582ca0: Loading layer [==================================================>]  15.44MB/15.44MB
+231bdbae9aea: Loading layer [==================================================>]  1.966MB/1.966MB
+a6dc470c72b7: Loading layer [==================================================>]  10.24kB/10.24kB
+a0de9c673ef6: Loading layer [==================================================>]  56.37MB/56.37MB
+84ff92691f90: Loading layer [==================================================>]  10.24kB/10.24kB
+Loaded image: gcr.io/prysmaticlabs/prysm/beacon-chain:latest
+Loaded image: prysmaticlabs/prysm-beacon-chain:latest
+```
+
+### Pushing to a container registry
+
+#### Authentication
+
+You can use these rules to access private images using standard Docker
+authentication methods.  e.g. to utilize the [Google Container Registry](
+https://gcr.io). See
+[here](https://cloud.google.com/container-registry/docs/advanced-authentication) for authentication methods.
+
+See:
+* [Amazon ECR Docker Credential Helper](
+  https://github.com/awslabs/amazon-ecr-credential-helper)
+* [Azure Docker Credential Helper](
+  https://github.com/Azure/acr-docker-credential-helper)
+
+#### Push
+
+To push the actual images, you do not need to build the image bundle beforehand. You can do a simple:
+
+```text
+bazel run //beacon-chain:push_images --config=release
+bazel run //validator:push_images --config=release
+```
+
+Which will deploy all images with the tags specified in [here](https://github.com/prysmaticlabs/prysm/blob/ff329df808ad68fbe79d11c73121fa6a7a0c0f29/cmd/beacon-chain/BUILD.bazel#L58) for the beacon-chain and [here](https://github.com/prysmaticlabs/prysm/blob/ff329df808ad68fbe79d11c73121fa6a7a0c0f29/cmd/validator/BUILD.bazel#L59) for the validator. 
+
+By default, this will deploy to Prysmatic Labs' Google Container Registry namespace: `gcr.io/prysmaticlabs/prysm`, which you will not have authentication access to, so make sure you edit the image tags to your appropriate registry and authenticate as needed.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/website/docs/install/install-with-bazel.md
+++ b/website/docs/install/install-with-bazel.md
@@ -175,19 +175,3 @@ bazel run //validator:push_images --config=release
 Which will deploy all images with the tags specified in [here](https://github.com/prysmaticlabs/prysm/blob/ff329df808ad68fbe79d11c73121fa6a7a0c0f29/cmd/beacon-chain/BUILD.bazel#L58) for the beacon-chain and [here](https://github.com/prysmaticlabs/prysm/blob/ff329df808ad68fbe79d11c73121fa6a7a0c0f29/cmd/validator/BUILD.bazel#L59) for the validator. 
 
 By default, this will deploy to Prysmatic Labs' Google Container Registry namespace: `gcr.io/prysmaticlabs/prysm`, which you will not have authentication access to, so make sure you edit the image tags to your appropriate registry and authenticate as needed.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/website/docs/install/install-with-bazel.md
+++ b/website/docs/install/install-with-bazel.md
@@ -35,7 +35,7 @@ These hardware specifications are recommended, but not required to run the Prysm
 ## Dependencies
 
 * A modern UNIX operating system
-* [Bazel](https://docs.bazel.build/versions/3.7.0/install.html) version **3.7.0** installed (Ensure you are doing 3.7.0)
+* [Bazel](https://docs.bazel.build/versions/3.7.0/install.html) version **3.7.0** installed (Ensure you are using 3.7.0)
 * The `cmake` package installed
 * The `git` package installed
 * `libssl-dev` installed

--- a/website/docs/install/install-with-docker.md
+++ b/website/docs/install/install-with-docker.md
@@ -42,9 +42,9 @@ These hardware specifications are recommended, but not required to run the Prysm
 
 ## Where are the Docker files?
 
-Instead of using the Dockerfiles, our team relies on the [Bazel](https://bazel.build) build system used by major companies to manage monorepositories. Bazel provides reproducible builds and a sandboxed environment that ensures everyone building Prysm has the same experience and can build our entire project from a single command. For more detailed rationale on why Bazel, how it works in Prysm, and all important information about how exactly building from source works, read our rationale [here](/docs/reading/bazel). That page also explains how we build the actual Docker images in Prysm today.
+Instead of using the Dockerfiles, our team relies on the [Bazel](https://bazel.build) build system used by major companies to manage monorepositories. Bazel provides reproducible builds and a sandboxed environment that ensures everyone building Prysm has the same experience and can build our entire project from a single command. To see how to build the Docker images yourself from scratch for your own purposes, see our instructions [here](/docs/install/install-with-bazel#building-docker-images).
 
-## Installing Prysm
+## Downloading the Prysm Docker images
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';

--- a/website/docs/reading/bazel.md
+++ b/website/docs/reading/bazel.md
@@ -63,7 +63,7 @@ All dependencies in the Prysm monorepo live in a file called `deps.bzl` at the t
 
 ### How to add new dependencies
 
-Adding new dependencies to Prysm requires specific changes. We have prepared a comprehensive [DEPENDENCIES.md](https://github.com/prysmaticlabs/prysm/blob/cff7dbd01582348d633f971a1e81e0c1a821db3d/DEPENDENCIES.md) explaining the required process.
+Adding new dependencies to Prysm requires specific changes. We have prepared a comprehensive [DEPENDENCIES.md](https://github.com/prysmaticlabs/prysm/blob/master/DEPENDENCIES.md) explaining the required process.
 
 ## Bazel and Docker
 
@@ -82,4 +82,3 @@ Everything in Prysm can be built with Bazel using `bazel build //...`. For examp
 ### With Go
 
 Building Prysm with Go is possible, but it will use precompiled cryptography to build the final executable. Additionally, it will not perform the compile-time optimizations Bazel does, and can have unexpected issues as you are relinquishing reproducible, hermetic builds which Bazel provides. We always recommend Bazel as the only way to run Prysm if you are planning on running it.
-

--- a/website/docs/reading/bazel.md
+++ b/website/docs/reading/bazel.md
@@ -32,6 +32,12 @@ Among a few cons of Bazel are:
 - Large, initial download of Bazel
 - Not enough, comprehensive IDE support for Bazel (although Jetbrains IDEs have good support)
 
+Thankfully, Prysm also builds with `go` and `go` modules as well, so your code editor can use its regular Go support when developing for Prysm.
+
+## BUILD Files
+
+Building with Bazel requires every directory and every package to have a BUILD.bazel file which tells it how it should build the code in question.
+
 ### Do I have to edit BUILD files myself?
 
 Most of the time, developers will not need to edit BUILD files themselves. Instead, they can use the following tool:
@@ -57,27 +63,15 @@ All dependencies in the Prysm monorepo live in a file called `deps.bzl` at the t
 
 ### How to add new dependencies
 
-In order to support a good developer experience, Prysm is also fully Go compatible, allowing users to use `go mod` as well to develop the project locally. Adding a new Go dependency can be done with:
+Adding new dependencies to Prysm requires specific changes. We have prepared a comprehensive [DEPENDENCIES.md](https://github.com/prysmaticlabs/prysm/blob/cff7dbd01582348d633f971a1e81e0c1a821db3d/DEPENDENCIES.md) explaining the required process.
 
-```text
-go get github.com/user/repo
-```
+## Bazel and Docker
 
-and then
+A common question we get is: "where are Prysm's Dockerfiles?". With Bazel, we get a ton of benefits in terms of optimizing our deployment and release process. In particular, we use [`bazel rules docker`](https://github.com/bazelbuild/rules_docker) which provides us the ability to specify a base, barebones image, and essentially builds our binary and creates a Docker container as a simple wrapper over our binaries. 
 
-```text
-bazel run //:gazelle -- update-repos -from_file=go.mod
-```
+We do not write our own Dockerfiles, as Bazel provides us a more sandboxed, simple experience with all of its benefits. To see an example use of `bazel rules docker` for how we build a particular package, see [here](https://github.com/prysmaticlabs/prysm/blob/aa389c82a157008741450ba1e04d898924734432/tools/bootnode/BUILD.bazel#L36). 
 
-## Docker and Bazel
-
-A common question we get is: "where are Prysm's Dockerfiles?". With Bazel, we get a ton of benefits in terms of optimizing our deployment and release process. In particular, we use [`bazel rules docker`](https://github.com/bazelbuild/rules_docker) which provides us the ability to specify a base, barebones image, and essentially builds our binary and creates a Docker container as a simple wrapper over our binaries. We do not write our own Dockerfiles, as Bazel provides us a more sandboxed, simple experience with all of its benefits. To see an example use of `bazel rules docker` for how we build a particular package, see [here](https://github.com/prysmaticlabs/prysm/blob/aa389c82a157008741450ba1e04d898924734432/tools/bootnode/BUILD.bazel#L36). In order to push to a registry, you will need to change the `container_bundle` to whatever name you want to give to your image, then run:
-
-```text
-bazel run //tools/bootnode:push_images
-```
-
-in the example above for our `bootnode` package.
+To read comprehensive instructions on how to build Prysm's docker images for your own use, see [here](/docs/install/install-with-bazel).
 
 ## Building Production Releases
 


### PR DESCRIPTION
This PR includes detailed instructions for building Prysm's docker images from source using Bazel, as well as fixes to pinned dependencies and better information for anyone attempting this