### PR TITLE
Update install-with-bazel.md

### DIFF
--- a/website/docs/install/install-with-bazel.md
+++ b/website/docs/install/install-with-bazel.md
@@ -34,8 +34,7 @@ These hardware specifications are recommended, but not required to run the Prysm
 
 ## Dependencies
 
-* A modern UNIX operating system
-* [Bazelisk](https://docs.bazel.build/versions/main/install.html) this will automatically manage the version of ***Bazel*** required. 
+* [Bazelisk](https://docs.bazel.build/versions/main/install-bazelisk.html) this will automatically manage the version of ***Bazel*** required. 
 * The `cmake` package installed
 * The `git` package installed
 * `libssl-dev` installed
@@ -60,14 +59,11 @@ You can install Bazelisk in multiple ways, including:
 
 ## Building Prysm from source
 
-1. Open a terminal window. Ensure you are running ***Bazel*** through the ***Bazelisk*** launcher by issuing the command: 
+:::tip Pro-Tip
+**NOTICE:** We recommend users install Bazelisk in the PATH in place of the Bazel binary. This can be done by simply replacing **/usr/local/bin/bazel** (*default location*) with the **bazelisk**  binary. This will ensure users no longer need to maintain the version of **bazel** in use. Full installation details and options for Bazelisk are available [Here.](https://github.com/bazelbuild/bazelisk/blob/master/README.md#installation) 
+:::
 
-```text
-bazelisk version
-``` 
-
-
-2. Clone Prysm's [main repository](https://github.com/prysmaticlabs/prysm), make sure you switch to the latest version (the latest version number can be found from the [releases page](https://github.com/prysmaticlabs/prysm/releases)), and enter the directory:
+1. Clone Prysm's [main repository](https://github.com/prysmaticlabs/prysm), make sure you switch to the latest version (the latest version number can be found from the [releases page](https://github.com/prysmaticlabs/prysm/releases)), and enter the directory:
 
 ```text
 git clone https://github.com/prysmaticlabs/prysm
@@ -75,11 +71,11 @@ git checkout <version>
 cd prysm
 ```
 
-3. Build both the beacon chain node and the validator client:
+2. Build both the beacon chain node and the validator client:
 
 ```text
-bazelisk build //beacon-chain:beacon-chain --config=release
-bazelisk build //validator:validator --config=release
+bazel build //beacon-chain:beacon-chain --config=release
+bazel build //validator:validator --config=release
 ```
 
 Bazelisk will automatically pull and install any dependencies as well, including Go and necessary compilers. Now that your installation is done, you can then read [joining eth2](/docs/mainnet/joining-eth2).
@@ -102,8 +98,8 @@ We do not write our own Dockerfiles, as Bazel provides us a more sandboxed, simp
 At the moment, Prysm docker images can only be built on **Linux** operating systems. The standard images are very thin wrappers around the Prysm beacon-chain and validator binaries, and do not contain any other typical components of Docker images such as a bash shell. These are the Docker images we ship to all users, and you can build them yourself as follows:
 
 ```bash
-bazelisk build //beacon-chain:image_bundle --config=release
-bazelisk build //validator:image_bundle --config=release
+bazel build //beacon-chain:image_bundle --config=release
+bazel build //validator:image_bundle --config=release
 ```
 
 The tags for the images are specified [here](https://github.com/prysmaticlabs/prysm/blob/ff329df808ad68fbe79d11c73121fa6a7a0c0f29/cmd/beacon-chain/BUILD.bazel#L58) for the beacon-chain and [here](https://github.com/prysmaticlabs/prysm/blob/ff329df808ad68fbe79d11c73121fa6a7a0c0f29/cmd/validator/BUILD.bazel#L59) for the validator. The default image tags for these images are:
@@ -120,8 +116,8 @@ You can edit these in the links above to your liking.
 Prysm also provides Alpine images built using:
 
 ```bash
-bazelisk build //beacon-chain:image_bundle_alpine --config=release
-bazelisk build //validator:image_bundle_alpine --config=release
+bazel build //beacon-chain:image_bundle_alpine --config=release
+bazel build //validator:image_bundle_alpine --config=release
 ```
 
 #### Debug images
@@ -129,8 +125,8 @@ bazelisk build //validator:image_bundle_alpine --config=release
 Prysm also provides debug images built using:
 
 ```bash
-bazelisk build //beacon-chain:image_bundle_debug --config=release
-bazelisk build //validator:image_bundle_debug --config=release
+bazel build //beacon-chain:image_bundle_debug --config=release
+bazel build //validator:image_bundle_debug --config=release
 ```
 
 ### Running images
@@ -138,8 +134,8 @@ bazelisk build //validator:image_bundle_debug --config=release
 You can load the images into your local Docker daemon by first building a `.tar` file as follows for your desired image bundle:
 
 ```text
-bazelisk build cmd/beacon-chain:image_bundle.tar
-bazelisk build cmd/validator:image_bundle.tar
+bazel build cmd/beacon-chain:image_bundle.tar
+bazel build cmd/validator:image_bundle.tar
 ```
 
 Then, you can load it into Docker with:
@@ -181,8 +177,8 @@ See:
 To push the actual images, you do not need to build the image bundle beforehand. You can do a simple:
 
 ```text
-bazelisk run //beacon-chain:push_images --config=release
-bazelisk run //validator:push_images --config=release
+bazel run //beacon-chain:push_images --config=release
+bazel run //validator:push_images --config=release
 ```
 
 Which will deploy all images with the tags specified in [here](https://github.com/prysmaticlabs/prysm/blob/ff329df808ad68fbe79d11c73121fa6a7a0c0f29/cmd/beacon-chain/BUILD.bazel#L58) for the beacon-chain and [here](https://github.com/prysmaticlabs/prysm/blob/ff329df808ad68fbe79d11c73121fa6a7a0c0f29/cmd/validator/BUILD.bazel#L59) for the validator. 

--- a/website/docs/install/install-with-bazel.md
+++ b/website/docs/install/install-with-bazel.md
@@ -78,7 +78,7 @@ bazel build //beacon-chain:beacon-chain --config=release
 bazel build //validator:validator --config=release
 ```
 
-Bazelisk will automatically pull and install any dependencies as well, including Go and necessary compilers. Now that your installation is done, you can then read [joining eth2](/docs/mainnet/joining-eth2).
+Bazel will automatically pull and install any dependencies as well, including Go and necessary compilers. Now that your installation is done, you can then read [joining eth2](/docs/mainnet/joining-eth2).
 
 ## Building Docker images
 

--- a/website/docs/install/install-with-bazel.md
+++ b/website/docs/install/install-with-bazel.md
@@ -7,7 +7,7 @@ sidebar_label: Building from source
 Prysm can be installed on GNU/Linux, MacOS, and Arm64 using our build tool, [Bazel](https://bazel.build). This page includes instructions for performing this method.
 
 :::tip Pro-Tip
-**NOTICE:** The Prysm installation script is the easiest and most efficient way of installing the latest binaries. Instructions for using it can be found [here](/docs/install/linux).
+**NOTICE:** We recommend users install Bazelisk, the user-friendly launcher for Bazel. It identifies and manages the required Bazel version for any repository you want to build.
 :::
 
 **Have questions?** Stop by the [#documentation](https://discord.gg/QQZMCgU) channel on Discord and let us know.
@@ -35,7 +35,7 @@ These hardware specifications are recommended, but not required to run the Prysm
 ## Dependencies
 
 * A modern UNIX operating system
-* [Bazel](https://docs.bazel.build/versions/3.7.0/install.html) version **3.7.0** installed (Ensure you are using 3.7.0)
+* [Bazelisk](https://docs.bazel.build/versions/main/install.html) this will automatically manage the version of ***Bazel*** required. 
 * The `cmake` package installed
 * The `git` package installed
 * `libssl-dev` installed
@@ -47,13 +47,25 @@ These hardware specifications are recommended, but not required to run the Prysm
 
 Instead of using the `Go` tool to build Prysm, our team relies on the [Bazel](https://bazel.build) build system used by major companies to manage monorepositories. Bazel provides reproducible builds and a sandboxed environment that ensures everyone building Prysm has the same experience and can build our entire project from a single command. For more detailed rationale on why Bazel, how it works in Prysm, and all important information about how exactly building from source works, read our rationale [here](/docs/reading/bazel).
 
+## Install Bazel using Bazelisk
+
+Bazelisk is a launcher for Bazel which automatically downloads and installs an appropriate version of Bazel. Use Bazelisk to automtically manage the version of Bazel required.  
+
+You can install Bazelisk in multiple ways, including:
+
+* npm install -g @bazel/bazelisk
+* Using a binary release for Linux, macOS, or Windows [(Download binaries)](https://github.com/bazelbuild/bazelisk/releases)
+* Using Homebrew on macOS
+* By compiling from source using Go: go get github.com/bazelbuild/bazelisk
+
 ## Building Prysm from source
 
-1. Open a terminal window. Ensure you are running the most recent version of Bazel by issuing the command:
+1. Open a terminal window. Ensure you are running ***Bazel*** through the ***Bazelisk*** launcher by issuing the command: 
 
 ```text
-bazel version
-```
+bazelisk version
+``` 
+
 
 2. Clone Prysm's [main repository](https://github.com/prysmaticlabs/prysm), make sure you switch to the latest version (the latest version number can be found from the [releases page](https://github.com/prysmaticlabs/prysm/releases)), and enter the directory:
 
@@ -66,11 +78,11 @@ cd prysm
 3. Build both the beacon chain node and the validator client:
 
 ```text
-bazel build //beacon-chain:beacon-chain --config=release
-bazel build //validator:validator --config=release
+bazelisk build //beacon-chain:beacon-chain --config=release
+bazelisk build //validator:validator --config=release
 ```
 
-Bazel will automatically pull and install any dependencies as well, including Go and necessary compilers. Now that your installation is done, you can then read [joining eth2](/docs/mainnet/joining-eth2).
+Bazelisk will automatically pull and install any dependencies as well, including Go and necessary compilers. Now that your installation is done, you can then read [joining eth2](/docs/mainnet/joining-eth2).
 
 ## Building Docker images
 
@@ -90,8 +102,8 @@ We do not write our own Dockerfiles, as Bazel provides us a more sandboxed, simp
 At the moment, Prysm docker images can only be built on **Linux** operating systems. The standard images are very thin wrappers around the Prysm beacon-chain and validator binaries, and do not contain any other typical components of Docker images such as a bash shell. These are the Docker images we ship to all users, and you can build them yourself as follows:
 
 ```bash
-bazel build //beacon-chain:image_bundle --config=release
-bazel build //validator:image_bundle --config=release
+bazelisk build //beacon-chain:image_bundle --config=release
+bazelisk build //validator:image_bundle --config=release
 ```
 
 The tags for the images are specified [here](https://github.com/prysmaticlabs/prysm/blob/ff329df808ad68fbe79d11c73121fa6a7a0c0f29/cmd/beacon-chain/BUILD.bazel#L58) for the beacon-chain and [here](https://github.com/prysmaticlabs/prysm/blob/ff329df808ad68fbe79d11c73121fa6a7a0c0f29/cmd/validator/BUILD.bazel#L59) for the validator. The default image tags for these images are:
@@ -108,8 +120,8 @@ You can edit these in the links above to your liking.
 Prysm also provides Alpine images built using:
 
 ```bash
-bazel build //beacon-chain:image_bundle_alpine --config=release
-bazel build //validator:image_bundle_alpine --config=release
+bazelisk build //beacon-chain:image_bundle_alpine --config=release
+bazelisk build //validator:image_bundle_alpine --config=release
 ```
 
 #### Debug images
@@ -117,8 +129,8 @@ bazel build //validator:image_bundle_alpine --config=release
 Prysm also provides debug images built using:
 
 ```bash
-bazel build //beacon-chain:image_bundle_debug --config=release
-bazel build //validator:image_bundle_debug --config=release
+bazelisk build //beacon-chain:image_bundle_debug --config=release
+bazelisk build //validator:image_bundle_debug --config=release
 ```
 
 ### Running images
@@ -126,8 +138,8 @@ bazel build //validator:image_bundle_debug --config=release
 You can load the images into your local Docker daemon by first building a `.tar` file as follows for your desired image bundle:
 
 ```text
-bazel build cmd/beacon-chain:image_bundle.tar
-bazel build cmd/validator:image_bundle.tar
+bazelisk build cmd/beacon-chain:image_bundle.tar
+bazelisk build cmd/validator:image_bundle.tar
 ```
 
 Then, you can load it into Docker with:
@@ -169,8 +181,8 @@ See:
 To push the actual images, you do not need to build the image bundle beforehand. You can do a simple:
 
 ```text
-bazel run //beacon-chain:push_images --config=release
-bazel run //validator:push_images --config=release
+bazelisk run //beacon-chain:push_images --config=release
+bazelisk run //validator:push_images --config=release
 ```
 
 Which will deploy all images with the tags specified in [here](https://github.com/prysmaticlabs/prysm/blob/ff329df808ad68fbe79d11c73121fa6a7a0c0f29/cmd/beacon-chain/BUILD.bazel#L58) for the beacon-chain and [here](https://github.com/prysmaticlabs/prysm/blob/ff329df808ad68fbe79d11c73121fa6a7a0c0f29/cmd/validator/BUILD.bazel#L59) for the validator. 


### PR DESCRIPTION
Updated the install with bazel documentation to include the recommendation that users run the  bazelisk wrapper  rather than specific versions of bazel.  This addresses #354