### PR TITLE
Correct commands and paths in Contribution Guidelines

### DIFF
--- a/website/docs/contribute/contribution-guidelines.md
+++ b/website/docs/contribute/contribution-guidelines.md
@@ -91,7 +91,7 @@ $ bazel test //beacon-chain/node:go_default_test
 For running a specific test, for example, a test called `TestNode_GetPeers` inside of `beacon-chain/node/node_test.go`, you can use Bazel to filter it out:
 
 ```text
-$ bazel test //beacon-chain/node:go_default_test --test_output=streamed --test_filter=TestNode_GetPeers
+$ bazel test //beacon-chain/rpc/prysm/v1alpha1/node:go_default_test --test_output=streamed --test_filter=TestNode_GetPeers
 ```
 
 For the list of all available flags to the `bazel test` command, you can see the reference documentation [here](https://docs.bazel.build/versions/master/command-line-reference.html#test).

--- a/website/docs/contribute/contribution-guidelines.md
+++ b/website/docs/contribute/contribution-guidelines.md
@@ -56,19 +56,8 @@ This will build the project by downloading dependencies as Go modules.
 
 All code we check into our repo needs to have sufficient tests to ensure it is maintainable and works as expected. You can use Go run tests in Prysm. 
 
-```text
-$ go test -v ./...
-```
-
-If there is a particular subfolder you want to test, such as `beacon-chain/rpc/node`, you can run the command:
-
-```text
-$ go test ./beacon-chain/rpc/node/...
-```
-
-#### Adding dependencies
-
-If you want to add a new dependency to Prysm, please adhere to the guidelines found in our [DEPENDENCIES.md](https://github.com/prysmaticlabs/prysm/blob/master/DEPENDENCIES.md) document.
+Many tests are rely on the Bazel build system, thus testing with `go test` would not work.
+See the [next section](#building-and-tessting-prysm-with-bazel) for instructions on testing with prysm.
 
 ### Building and testing Prysm with Bazel
 
@@ -112,6 +101,10 @@ You can also run our full, end-to-end test suite with:
 ```text
 $ bazel test //testing/endtoend:go_default_test
 ```
+
+#### Adding dependencies
+
+If you want to add a new dependency to Prysm, please adhere to the guidelines found in our [DEPENDENCIES.md](https://github.com/prysmaticlabs/prysm/blob/master/DEPENDENCIES.md) document.
 
 ### Contributing to the Eth2 API
 

--- a/website/docs/contribute/contribution-guidelines.md
+++ b/website/docs/contribute/contribution-guidelines.md
@@ -93,16 +93,16 @@ You can also find various other types of IDE support for Bazel in the official B
 
 #### Running Bazel tests
 
-All code we check into our repo needs to have sufficient tests to ensure it is maintainable and works as expected. We use bazel to run all of our test suites in Prysm. If there is a particular subfolder you want to test, such as `beacon-chain/rpc/node`, you can run the command:
+All code we check into our repo needs to have sufficient tests to ensure it is maintainable and works as expected. We use bazel to run all of our test suites in Prysm. If there is a particular subfolder you want to test, such as `beacon-chain/node`, you can run the command:
 
 ```text
-$ bazel test //beacon-chain/rpc/node:go_default_test
+$ bazel test //beacon-chain/node:go_default_test
 ```
 
 For running a specific test, for example, a test called `TestNode_GetPeers` inside of `beacon-chain/node/node_test.go`, you can use Bazel to filter it out:
 
 ```text
-$ bazel test //beacon-chain/rpc/node:go_default_test --test_output=streamed --test_filter=TestNode_GetPeers
+$ bazel test //beacon-chain/node:go_default_test --test_output=streamed --test_filter=TestNode_GetPeers
 ```
 
 For the list of all available flags to the `bazel test` command, you can see the reference documentation [here](https://docs.bazel.build/versions/master/command-line-reference.html#test).
@@ -110,7 +110,7 @@ For the list of all available flags to the `bazel test` command, you can see the
 You can also run our full, end-to-end test suite with:
 
 ```text
-$ bazel test //endtoend:go_default_test --define=ssz=minimal
+$ bazel test //testing/endtoend:go_default_test
 ```
 
 ### Contributing to the Eth2 API


### PR DESCRIPTION
Some of the commands listed in the Contribution Guide are outdated - namely:
1. Some of the paths have `cmd/` or `testing/` prefixed to them
2. `go test ./...` fails, since many tests rely on bazel.

I've taken some artistic freedom regarding point No. 2. Let me know if you want this delt with another way.

I have also moved the "Adding dependencies" to after the bazel section. 
Formerly it was between the "Running" and "Running with bazel" sections, which didn't make too much sense.