### PR TITLE
Update Prater Eth2 Launchpad url

### DIFF
--- a/website/versioned_docs/version-2.0.0/install/install-with-docker.md
+++ b/website/versioned_docs/version-2.0.0/install/install-with-docker.md
@@ -385,7 +385,7 @@ If your node is done synchronizing, you will see the response:
 The correct address for the launchpad is https://launchpad.ethereum.org and the only, official validator deposit contract is [0x00000000219ab540356cbb839cbe05303d7705fa](https://etherscan.io/address/0x00000000219ab540356cbb839cbe05303d7705fa). Do not send ETH directly to the contract, and only join by using the eth2 launchpad.
 :::
 
-The [Mainnet Eth2 Launchpad](https://launchpad.ethereum.org/summary) is the easiest way to go through a step-by-step process to deposit your 32 ETH to become a validator. If you want to participate in the **testnet**, you can navigte to the [Prater Eth2 Launchpad](https://prater.launchpad.net/summary) instead
+The [Mainnet Eth2 Launchpad](https://launchpad.ethereum.org/summary) is the easiest way to go through a step-by-step process to deposit your 32 ETH to become a validator. If you want to participate in the **testnet**, you can navigte to the [Prater Eth2 Launchpad](https://prater.launchpad.ethereum.org/en/overview) instead
 
 Throughout the process, you'll be asked to generate new validator credentials using the official Ethereum deposit command-line-tool [here](https://github.com/ethereum/eth2.0-deposit-cli). Make sure you use the `mainnet` option when generating keys with the deposit CLI. During the process, you will have generated a `validator_keys` folder under the `eth2.0-deposit-cli` directory. You can import all of your validator keys into Prysm from that folder in the next step.
 


### PR DESCRIPTION
It appears that the `Prater Eth2 Launchpad` has moved, and the current link is invalid. I've updated the link to point to the new "summary page" on the Prater Testnet's Launchpad site.