### PR TITLE
Change Link to Directly Reference Genesis File

### DIFF
--- a/website/docs/install/install-with-bazel.md
+++ b/website/docs/install/install-with-bazel.md
@@ -113,7 +113,7 @@ bazel run //beacon-chain --config=release -- --http-web3provider=<YOUR_ETH1_NODE
 
 **Prater**
 
-Download the genesis state from [github.com/eth2-clients/eth2-networks/blob/master/shared/prater/genesis.ssz](https://github.com/eth2-clients/eth2-networks/blob/master/shared/prater/genesis.ssz) to a local file, then run
+Download the genesis state from [github.com/eth2-clients/eth2-networks/raw/master/shared/prater/genesis.ssz](https://github.com/eth2-clients/eth2-networks/raw/master/shared/prater/genesis.ssz) to a local file, then run
 
 ```text
 bazel run //beacon-chain --config=release -- --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT> --prater --genesis-state=/path/to/genesis.ssz

--- a/website/docs/install/install-with-docker.md
+++ b/website/docs/install/install-with-docker.md
@@ -269,7 +269,7 @@ docker run -it -v $HOME/.eth2:/data -p 4000:4000 -p 13000:13000 -p 12000:12000/u
 
 **Prater**
 
-Download the genesis state from [github.com/eth2-clients/eth2-networks/blob/master/shared/prater/genesis.ssz](https://github.com/eth2-clients/eth2-networks/blob/master/shared/prater/genesis.ssz) to a local file, then run
+Download the genesis state from [github.com/eth2-clients/eth2-networks/raw/master/shared/prater/genesis.ssz](https://github.com/eth2-clients/eth2-networks/raw/master/shared/prater/genesis.ssz) to a local file, then run
 
 ```text
 docker run -it -v $HOME/.eth2:/data -v /path/to/genesis.ssz:/genesis/genesis.ssz -p 4000:4000 -p 13000:13000 -p 12000:12000/udp --name beacon-node \
@@ -305,7 +305,7 @@ This will sync up the beacon node with the latest cannonical head block in the n
 
 **Prater**
 
-Download the genesis state from [github.com/eth2-clients/eth2-networks/blob/master/shared/prater/genesis.ssz](https://github.com/eth2-clients/eth2-networks/blob/master/shared/prater/genesis.ssz) to a local file, then run
+Download the genesis state from [github.com/eth2-clients/eth2-networks/raw/master/shared/prater/genesis.ssz](https://github.com/eth2-clients/eth2-networks/raw/master/shared/prater/genesis.ssz) to a local file, then run
 
 
 ```text
@@ -330,7 +330,7 @@ docker run -it -v $HOME/.eth2:/data -p 4000:4000 -p 13000:13000 -p 12000:12000/u
 
 **Prater**
 
-Download the genesis state from [github.com/eth2-clients/eth2-networks/blob/master/shared/prater/genesis.ssz](https://github.com/eth2-clients/eth2-networks/blob/master/shared/prater/genesis.ssz) to a local file, then run
+Download the genesis state from [github.com/eth2-clients/eth2-networks/raw/master/shared/prater/genesis.ssz](https://github.com/eth2-clients/eth2-networks/raw/master/shared/prater/genesis.ssz) to a local file, then run
 
 ```text
 docker run -it -v $HOME/.eth2:/data -v /path/to/genesis.ssz:/genesis/genesis.ssz -p 4000:4000 -p 13000:13000 -p 12000:12000/udp --name beacon-node \

--- a/website/docs/install/install-with-script.md
+++ b/website/docs/install/install-with-script.md
@@ -171,7 +171,7 @@ Note: <YOUR_ETH1_NODE_ENDPOINT> is in the format of an http endpoint such as `ht
 
 **Prater**
 
-Download the genesis state from [github.com/eth2-clients/eth2-networks/blob/master/shared/prater/genesis.ssz](https://github.com/eth2-clients/eth2-networks/blob/master/shared/prater/genesis.ssz) to a local file, then run
+Download the genesis state from [github.com/eth2-clients/eth2-networks/raw/master/shared/prater/genesis.ssz](https://github.com/eth2-clients/eth2-networks/raw/master/shared/prater/genesis.ssz) to a local file, then run
 
 ```text
 ./prysm.sh beacon-chain --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT> --prater --genesis-state=/path/to/genesis.ssz
@@ -190,7 +190,7 @@ prysm.bat beacon-chain --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT>
 
 **Prater**
 
-Download the genesis state from [github.com/eth2-clients/eth2-networks/blob/master/shared/prater/genesis.ssz](https://github.com/eth2-clients/eth2-networks/blob/master/shared/prater/genesis.ssz) to a local file, then run
+Download the genesis state from [github.com/eth2-clients/eth2-networks/raw/master/shared/prater/genesis.ssz](https://github.com/eth2-clients/eth2-networks/raw/master/shared/prater/genesis.ssz) to a local file, then run
 
 ```text
 prysm.bat beacon-chain --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT> --prater --genesis-state=\path\to\genesis.ssz
@@ -209,7 +209,7 @@ Note: <YOUR_ETH1_NODE_ENDPOINT> is in the format of an http endpoint such as `ht
 
 **Prater**
 
-Download the genesis state from [github.com/eth2-clients/eth2-networks/blob/master/shared/prater/genesis.ssz](https://github.com/eth2-clients/eth2-networks/blob/master/shared/prater/genesis.ssz) to a local file, then run
+Download the genesis state from [github.com/eth2-clients/eth2-networks/raw/master/shared/prater/genesis.ssz](https://github.com/eth2-clients/eth2-networks/raw/master/shared/prater/genesis.ssz) to a local file, then run
 
 ```text
 ./prysm.sh beacon-chain --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT> --prater --genesis-state=/path/to/genesis.ssz
@@ -228,7 +228,7 @@ Note: <YOUR_ETH1_NODE_ENDPOINT> is in the format of an http endpoint such as `ht
 
 **Prater**
 
-Download the genesis state from [github.com/eth2-clients/eth2-networks/blob/master/shared/prater/genesis.ssz](https://github.com/eth2-clients/eth2-networks/blob/master/shared/prater/genesis.ssz) to a local file, then run
+Download the genesis state from [github.com/eth2-clients/eth2-networks/raw/master/shared/prater/genesis.ssz](https://github.com/eth2-clients/eth2-networks/raw/master/shared/prater/genesis.ssz) to a local file, then run
 
 ```text
 ./prysm.sh beacon-chain --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT> --prater --genesis-state=/path/to/genesis.ssz

--- a/website/versioned_docs/version-2.0.0/install/install-with-bazel.md
+++ b/website/versioned_docs/version-2.0.0/install/install-with-bazel.md
@@ -113,7 +113,7 @@ bazel run //beacon-chain --config=release -- --http-web3provider=<YOUR_ETH1_NODE
 
 **Prater**
 
-Download the genesis state from [github.com/eth2-clients/eth2-networks/blob/master/shared/prater/genesis.ssz](https://github.com/eth2-clients/eth2-networks/blob/master/shared/prater/genesis.ssz) to a local file, then run
+Download the genesis state from [github.com/eth2-clients/eth2-networks/raw/master/shared/prater/genesis.ssz](https://github.com/eth2-clients/eth2-networks/raw/master/shared/prater/genesis.ssz) to a local file, then run
 
 ```text
 bazel run //beacon-chain --config=release -- --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT> --prater --genesis-state=/path/to/genesis.ssz

--- a/website/versioned_docs/version-2.0.0/install/install-with-docker.md
+++ b/website/versioned_docs/version-2.0.0/install/install-with-docker.md
@@ -269,7 +269,7 @@ docker run -it -v $HOME/.eth2:/data -p 4000:4000 -p 13000:13000 -p 12000:12000/u
 
 **Prater**
 
-Download the genesis state from [github.com/eth2-clients/eth2-networks/blob/master/shared/prater/genesis.ssz](https://github.com/eth2-clients/eth2-networks/blob/master/shared/prater/genesis.ssz) to a local file, then run
+Download the genesis state from [github.com/eth2-clients/eth2-networks/raw/master/shared/prater/genesis.ssz](https://github.com/eth2-clients/eth2-networks/raw/master/shared/prater/genesis.ssz) to a local file, then run
 
 ```text
 docker run -it -v $HOME/.eth2:/data -v /path/to/genesis.ssz:/genesis/genesis.ssz -p 4000:4000 -p 13000:13000 -p 12000:12000/udp --name beacon-node \
@@ -305,7 +305,7 @@ This will sync up the beacon node with the latest cannonical head block in the n
 
 **Prater**
 
-Download the genesis state from [github.com/eth2-clients/eth2-networks/blob/master/shared/prater/genesis.ssz](https://github.com/eth2-clients/eth2-networks/blob/master/shared/prater/genesis.ssz) to a local file, then run
+Download the genesis state from [github.com/eth2-clients/eth2-networks/raw/master/shared/prater/genesis.ssz](https://github.com/eth2-clients/eth2-networks/raw/master/shared/prater/genesis.ssz) to a local file, then run
 
 
 ```text
@@ -330,7 +330,7 @@ docker run -it -v $HOME/.eth2:/data -p 4000:4000 -p 13000:13000 -p 12000:12000/u
 
 **Prater**
 
-Download the genesis state from [github.com/eth2-clients/eth2-networks/blob/master/shared/prater/genesis.ssz](https://github.com/eth2-clients/eth2-networks/blob/master/shared/prater/genesis.ssz) to a local file, then run
+Download the genesis state from [github.com/eth2-clients/eth2-networks/raw/master/shared/prater/genesis.ssz](https://github.com/eth2-clients/eth2-networks/raw/master/shared/prater/genesis.ssz) to a local file, then run
 
 ```text
 docker run -it -v $HOME/.eth2:/data -v /path/to/genesis.ssz:/genesis/genesis.ssz -p 4000:4000 -p 13000:13000 -p 12000:12000/udp --name beacon-node \

--- a/website/versioned_docs/version-2.0.0/install/install-with-script.md
+++ b/website/versioned_docs/version-2.0.0/install/install-with-script.md
@@ -171,7 +171,7 @@ Note: <YOUR_ETH1_NODE_ENDPOINT> is in the format of an http endpoint such as `ht
 
 **Prater**
 
-Download the genesis state from [github.com/eth2-clients/eth2-networks/blob/master/shared/prater/genesis.ssz](https://github.com/eth2-clients/eth2-networks/blob/master/shared/prater/genesis.ssz) to a local file, then run
+Download the genesis state from [github.com/eth2-clients/eth2-networks/raw/master/shared/prater/genesis.ssz](https://github.com/eth2-clients/eth2-networks/raw/master/shared/prater/genesis.ssz) to a local file, then run
 
 ```text
 ./prysm.sh beacon-chain --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT> --prater --genesis-state=/path/to/genesis.ssz
@@ -190,7 +190,7 @@ prysm.bat beacon-chain --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT>
 
 **Prater**
 
-Download the genesis state from [github.com/eth2-clients/eth2-networks/blob/master/shared/prater/genesis.ssz](https://github.com/eth2-clients/eth2-networks/blob/master/shared/prater/genesis.ssz) to a local file, then run
+Download the genesis state from [github.com/eth2-clients/eth2-networks/raw/master/shared/prater/genesis.ssz](https://github.com/eth2-clients/eth2-networks/raw/master/shared/prater/genesis.ssz) to a local file, then run
 
 ```text
 prysm.bat beacon-chain --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT> --prater --genesis-state=\path\to\genesis.ssz
@@ -209,7 +209,7 @@ Note: <YOUR_ETH1_NODE_ENDPOINT> is in the format of an http endpoint such as `ht
 
 **Prater**
 
-Download the genesis state from [github.com/eth2-clients/eth2-networks/blob/master/shared/prater/genesis.ssz](https://github.com/eth2-clients/eth2-networks/blob/master/shared/prater/genesis.ssz) to a local file, then run
+Download the genesis state from [github.com/eth2-clients/eth2-networks/raw/master/shared/prater/genesis.ssz](https://github.com/eth2-clients/eth2-networks/raw/master/shared/prater/genesis.ssz) to a local file, then run
 
 ```text
 ./prysm.sh beacon-chain --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT> --prater --genesis-state=/path/to/genesis.ssz
@@ -228,7 +228,7 @@ Note: <YOUR_ETH1_NODE_ENDPOINT> is in the format of an http endpoint such as `ht
 
 **Prater**
 
-Download the genesis state from [github.com/eth2-clients/eth2-networks/blob/master/shared/prater/genesis.ssz](https://github.com/eth2-clients/eth2-networks/blob/master/shared/prater/genesis.ssz) to a local file, then run
+Download the genesis state from [github.com/eth2-clients/eth2-networks/raw/master/shared/prater/genesis.ssz](https://github.com/eth2-clients/eth2-networks/raw/master/shared/prater/genesis.ssz) to a local file, then run
 
 ```text
 ./prysm.sh beacon-chain --http-web3provider=<YOUR_ETH1_NODE_ENDPOINT> --prater --genesis-state=/path/to/genesis.ssz


### PR DESCRIPTION
This fixes our documentation to link to the file directly rather than simply the github page which hosts it. 