### PR TITLE
docs: Update the downgrade documentation for systemd

### DIFF
--- a/website/versioned_docs/version-2.0.3/prysm-usage/staying-up-to-date.md
+++ b/website/versioned_docs/version-2.0.3/prysm-usage/staying-up-to-date.md
@@ -170,7 +170,7 @@ To run our latest release with Bazel, you can look up our [releases page](https:
 
 **Using Systemd**
   
-Edit the systemd files for both validator (`/etc/systemd/system/beacon.service`) and beacon (`/etc/systemd/system/beacon.service`). The filename  depends on what you used when you installed, if you forgot the name, just `ls` that directory (`/etc/systemd/system/`) and edit them both. Add the `Environment` key under the `[Service]` group to have `Environment     =  USE_PRYSM_VERSION=v2.0.2`
+Edit the systemd files for both validator (`/etc/systemd/system/validator.service`) and beacon (`/etc/systemd/system/beacon.service`). The filename  depends on what you used when you installed, if you forgot the name, just `ls` that directory (`/etc/systemd/system/`) and edit them both. Add the `Environment` key under the `[Service]` group to have `Environment     =  USE_PRYSM_VERSION=v2.0.2`
   
 Example for the beacon chain:
 ```

--- a/website/versioned_docs/version-2.0.3/prysm-usage/staying-up-to-date.md
+++ b/website/versioned_docs/version-2.0.3/prysm-usage/staying-up-to-date.md
@@ -191,7 +191,7 @@ Environment     = USE_PRYSM_VERSION=v2.0.2
 WantedBy    = multi-user.target
 ```
   
-After you finish editing both of the files, you need to restart systemd:
+After you finish editing both of the files, you need to reload the service unit
 ```
 sudo systemctl daemon-reload
 ```

--- a/website/versioned_docs/version-2.0.3/prysm-usage/staying-up-to-date.md
+++ b/website/versioned_docs/version-2.0.3/prysm-usage/staying-up-to-date.md
@@ -196,7 +196,7 @@ After you finish editing both of the files, you need to reload the service unit
 sudo systemctl daemon-reload
 ```
 
-Once you do that, the version of prysm beacon and validator are locked in that version, so you need to always update it. If you want to go back to the automatic upgrades after reboot, you just need to remove the `Environment` key.
+Once you do that, the prysm beacon and validator are locked in that version, so you need to always update it. If you want to go back to the automatic upgrades after reboot, you just need to remove the `Environment` key.
 
 </TabItem>
 <TabItem value="win">

--- a/website/versioned_docs/version-2.0.3/prysm-usage/staying-up-to-date.md
+++ b/website/versioned_docs/version-2.0.3/prysm-usage/staying-up-to-date.md
@@ -168,6 +168,36 @@ To run a previous Prysm version with Docker, choose the release you want to run,
 
 To run our latest release with Bazel, you can look up our [releases page](https://github.com/prysmaticlabs/prysm/releases), look at the release tag you want to run, such as v1.0.5, then do `git checkout v1.0.5`. Afterwards, you can re-run your beacon chain and validator as you ran them earlier with Bazel.
 
+**Using Systemd**
+  
+Edit the systemd files for both validator (`/etc/systemd/system/beacon.service`) and beacon (`/etc/systemd/system/beacon.service`). The filename  depends on what you used when you installed, if you forgot the name, just `ls` that directory (`/etc/systemd/system/`) and edit them both. Add the `Environment` key under the `[Service]` group to have `Environment     =  USE_PRYSM_VERSION=v2.0.2`
+  
+Example for the beacon chain:
+```
+[Unit]
+Description     = Ethereum Beacon Chain Service
+Wants           = network-online.target
+After           = network-online.target
+
+[Service]
+Type            = simple
+User            = eth
+ExecStart       = /home/eth/prysm/prysm.sh beacon-chain --config-file=/etc/prysm/beacon-chain.yaml
+Restart         = on-failure
+TimeoutStopSec  = 900
+Environment     = USE_PRYSM_VERSION=v2.0.2
+
+[Install]
+WantedBy    = multi-user.target
+```
+  
+After you finish editing both of the files, you need to restart systemd:
+```
+sudo systemctl daemon-reload
+```
+
+Once you do that, the version of prysm beacon and validator are locked in that version, so you need to always update it. If you want to go back to the automatic upgrades after reboot, you just need to remove the `Environment` key.
+
 </TabItem>
 <TabItem value="win">
 


### PR DESCRIPTION
The documentation didn't show how to downgrade systemd service and a lot of users were having problems. This hopefully makes it clearer.