### PR TITLE
Fix comment in good example in error handling

### DIFF
--- a/website/docs/contribute/prysms-golang-principles.md
+++ b/website/docs/contribute/prysms-golang-principles.md
@@ -85,11 +85,10 @@ func UpdateBeaconState(currentState *pb.BeaconState, blockCh chan<- *types.Block
       Case block :=<-blockCh:
         If err != processBlock(block); err != nil {
           log.Errorf(“block failed processing conditions: %v”, err)
+          // GOOD: The line below won't save to DB if block failed processing conditions.
           continue
         }
         newState := executeStateTransition(currentState, block)
-        // BAD: This can lead to a critical, inconsistent state! The line below will save to DB
-        // DB even if block failed processing conditions!
         db.SaveState(newState)
     }
   }

--- a/website/versioned_docs/version-1.x.x/contribute/prysms-golang-principles.md
+++ b/website/versioned_docs/version-1.x.x/contribute/prysms-golang-principles.md
@@ -85,11 +85,10 @@ func UpdateBeaconState(currentState *pb.BeaconState, blockCh chan<- *types.Block
       Case block :=<-blockCh:
         If err != processBlock(block); err != nil {
           log.Errorf(“block failed processing conditions: %v”, err)
+          // GOOD: The line below won't save to DB if block failed processing conditions.
           continue
         }
         newState := executeStateTransition(currentState, block)
-        // BAD: This can lead to a critical, inconsistent state! The line below will save to DB
-        // DB even if block failed processing conditions!
         db.SaveState(newState)
     }
   }

--- a/website/versioned_docs/version-2.0.0/contribute/prysms-golang-principles.md
+++ b/website/versioned_docs/version-2.0.0/contribute/prysms-golang-principles.md
@@ -85,11 +85,10 @@ func UpdateBeaconState(currentState *pb.BeaconState, blockCh chan<- *types.Block
       Case block :=<-blockCh:
         If err != processBlock(block); err != nil {
           log.Errorf(“block failed processing conditions: %v”, err)
+          // GOOD: The line below won't save to DB if block failed processing conditions.
           continue
         }
         newState := executeStateTransition(currentState, block)
-        // BAD: This can lead to a critical, inconsistent state! The line below will save to DB
-        // DB even if block failed processing conditions!
         db.SaveState(newState)
     }
   }

--- a/website/versioned_docs/version-2.0.3/contribute/prysms-golang-principles.md
+++ b/website/versioned_docs/version-2.0.3/contribute/prysms-golang-principles.md
@@ -85,11 +85,10 @@ func UpdateBeaconState(currentState *pb.BeaconState, blockCh chan<- *types.Block
       Case block :=<-blockCh:
         If err != processBlock(block); err != nil {
           log.Errorf(“block failed processing conditions: %v”, err)
+          // GOOD: The line below won't save to DB if block failed processing conditions.
           continue
         }
         newState := executeStateTransition(currentState, block)
-        // BAD: This can lead to a critical, inconsistent state! The line below will save to DB
-        // DB even if block failed processing conditions!
         db.SaveState(newState)
     }
   }

--- a/website/versioned_docs/version-2.0.6/contribute/prysms-golang-principles.md
+++ b/website/versioned_docs/version-2.0.6/contribute/prysms-golang-principles.md
@@ -85,11 +85,10 @@ func UpdateBeaconState(currentState *pb.BeaconState, blockCh chan<- *types.Block
       Case block :=<-blockCh:
         If err != processBlock(block); err != nil {
           log.Errorf(“block failed processing conditions: %v”, err)
+          // GOOD: The line below won't save to DB if block failed processing conditions.
           continue
         }
         newState := executeStateTransition(currentState, block)
-        // BAD: This can lead to a critical, inconsistent state! The line below will save to DB
-        // DB even if block failed processing conditions!
         db.SaveState(newState)
     }
   }


### PR DESCRIPTION
Was probably a copy/paste error.

The good example still have the "BAD" comment.

https://docs.prylabs.network/docs/next/contribute/golang-principles/#error-handling