### PR TITLE
FAQ Improvements (vNext only)

### DIFF
--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -1,31 +1,29 @@
 ---
 id: faq
 title: Frequently asked questions
-sidebar_label: Frequently asked questions
+sidebar_label: Troubleshooting FAQ
 ---
-
-## Troubleshooting Prysm
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-#### Help, I see this error and don't know what it means!
 
-If you have seen a scary ERROR log in your beacon node or validator, there are few things you should do first. Go to our [open issues](https://github.com/prysmaticlabs/prysm/issues) to see if someone has reported the same problem before. Otherwise, note the Prysm version you are running, your operating system, and file a bug report [here](https://github.com/prysmaticlabs/prysm/issues/new?assignees=&labels=&template=bug_report.md). You can also ask our community on [discord](https://discord.gg/prysmaticlabs) about your error and we will take a look as soon as possible.
+## Frequently asked questions
+
+### Troubleshooting Prysm
+
+#### How do I troubleshoot errors?
+
+If your beacon node or validator logs display an `ERROR`, go to our [open issues](https://github.com/prysmaticlabs/prysm/issues) to see if someone has reported the same problem before. If this doesn't help, note the **Prysm version you're running** and your **operating system**, and then file a bug report [here](https://github.com/prysmaticlabs/prysm/issues/new?assignees=&labels=&template=bug_report.md). You can also ask our community on [discord](https://discord.gg/prysmaticlabs) about your error and we'll take a look as soon as possible.
 
 #### My validator is losing money, what's going on?
 
-If your validators are performing poorly and losing money, there are few pieces of information we need to help you out.
-
-**Things you can do**
-
-1. Check if your node or validator client crashed. You can view the logs of the process to see if there were any ERROR logs. If so, please file a bug report or talk to our team on [discord](https://discord.gg/prysmaticlabs). A fatal crash is quite serious and something we will investigate right away. You can try restarting your processes in the meantime to see if you can be fully operational again.
+1. Try restarting your machine and associated processes.
+1. See if your node or validator client crashed. You can view the logs of the process to see if there were any `ERROR` logs. If so, please file a bug report or talk to our team on [discord](https://discord.gg/prysmaticlabs). A fatal crash is quite serious and something we'll investigate right away.
 2. Check your network connectivity. You can improve this by following our tips [here](/docs/prysm-usage/p2p-host-ip) which can help you find better peers, improve attestation effectiveness, and more.
 3. Check your system resource usage, perhaps your node is using excess CPU and RAM. Depending on your operating system, there are different ways to do this.
 
-**Things we can do**
-
-If your issue has not yet been resolved, please do the following. Note your Prysm version and operating system, ensure none of the issues are above were the root cause of your problem, then reach out to our team on [Discord](https://discord.gg/prysmaticlabs). We need as much information about error logs or other issues you may be seeing to effectively answer your questions and get you back to validating correctly.
+If you still need help, note your **Prysm version** and **operating system**, and then reach out to our team on [Discord](https://discord.gg/prysmaticlabs). Providing as much information as possible will help us troubleshoot your issue.
 
 #### My node suddenly lost peers, what can I do?
 
@@ -33,7 +31,7 @@ Losing peers can be due the following reasons:
 
 1. Your network connectivity has problems. You can check how to improve it with some of our tips [here](/docs/prysm-usage/p2p-host-ip).
 2. Prysm is using a ton of memory or system resources and perhaps you ran out of memory. Ensure you meet the minimum specifications for runnuing Prysm specified in our installation pages for your operating system.
-3. A bug in our software that can affect your p2p connectivity. It is known that certain versions have issues with peers on operating systems such as Windows, so you could try [downgrading](/docs/prysm-usage/staying-up-to-date) to see if your issue is resolved. If this is the case, talk to our team on [Discord](https://discord.gg/prysmaticlabs) letting us know you had this issue
+3. A bug in our software that can affect your p2p connectivity. It is known that certain versions have issues with peers on operating systems such as Windows, so you could try [downgrading](/docs/prysm-usage/staying-up-to-date) to see if your issue is resolved. If this is the case, talk to our team on [Discord](https://discord.gg/prysmaticlabs) letting us know you had this issue.
 
 #### I have an issue in the web UI, getting errors, what can I do?
 
@@ -66,11 +64,11 @@ The most common way validators get slashed is by **running the same validator ke
 
 Our team prepared a blog post on [slashing prevention tips](https://medium.com/prysmatic-labs/eth2-slashing-prevention-tips-f6faa5025f50) you can read to avoid slashings in the future.
 
-## Running Prysm
+### Running Prysm
 
 #### How can I check my Prysm version?
 
-Depending on your installation method, there are different ways to verify your prysm version:
+Depending on your installation method, there are different ways to verify your Prysm version:
 
 <Tabs
   groupId="method"
@@ -168,7 +166,7 @@ Your node is running the popular [prometheus](https://prometheus.io/) server for
 
 Yes we currently support arm 64-bit architectures such as the raspberry pi 4 and they go out as part of our pre-compiled binary releases [here](https://github.com/prysmaticlabs/prysm/releases). Our documentation portal has instructions on how to run the entire installation process [here](/docs/install/install-with-script). However, we recommend using more powerful hardware in mainnet conditions. 
 
-## Validator keys and validator deposits
+### Validator keys and validator deposits
 
 #### I sent my deposit and so much time has passed but my validator is not active yet
 
@@ -203,7 +201,14 @@ Adding new validators to your already-running Prysm instance is quite simple! Go
 
 Please note you will need to **restart the validator client** after importing the new one for the changes to take effect.
 
-## Ethereum proof-of-stake specific questions
+### Ethereum proof-of-stake specific questions
+
+#### How do I check my current validator balance?
+The easiest way to check your current validator account balance is to search for your validator public key in a blockchain explorer like [beaconchai.in](https://beaconcha.in/).
+
+<!--todo: explain how -->
+If you have a fully synced beacon node, you can fetch your account balance via the beacon node API.
+
 
 #### Why are some validators making a lot more money than others?
 

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -29,7 +29,7 @@ If you still need help, note your **Prysm version** and **operating system**, an
 Losing peers can be due the following reasons:
 
 1. Your network connectivity has problems. You can check how to improve it with some of our tips [here](/docs/prysm-usage/p2p-host-ip).
-2. Prysm is using a ton of memory or system resources and perhaps you ran out of memory. Ensure you meet the minimum specifications for runnuing Prysm specified in our installation pages for your operating system.
+2. Prysm is using a ton of memory or system resources and perhaps you ran out of memory. Ensure you meet the minimum specifications for running Prysm specified in our installation pages for your operating system.
 3. A bug in our software that can affect your p2p connectivity. It is known that certain versions have issues with peers on operating systems such as Windows, so you could try [downgrading](/docs/prysm-usage/staying-up-to-date) to see if your issue is resolved. If this is the case, talk to our team on [Discord](https://discord.gg/prysmaticlabs) letting us know you had this issue.
 
 #### I have an issue in the web UI, getting errors, what can I do?
@@ -97,7 +97,7 @@ prysm.bat beacon-chain --version
 </TabItem>
 <TabItem value="docker">
 
-If you are running using docker and the :stable tag for Prysm, stable will always point to our latest [release](https://github.com/prysmaticlabs/prysm/releases). Otherwise, you can run the command `docker ps` to see your running docker containers. The suffix of your image name after the colon is the version you are runnning.
+If you are running using docker and the :stable tag for Prysm, stable will always point to our latest [release](https://github.com/prysmaticlabs/prysm/releases). Otherwise, you can run the command `docker ps` to see your running docker containers. The suffix of your image name after the colon is the version you are running.
 
 ```
 CONTAINER ID        IMAGE                  COMMAND                  CREATED             STATUS              PORTS               NAMES
@@ -137,7 +137,7 @@ For help with running geth specifically, the [go-ethereum discord](https://disco
 
 #### How often should I perform database backups?
 
-The Prysm beacon node and validator allow performing database backups in case your machine gets corrupted and you need to restore it from some checkpoint. You can read our instructions on performing backups [here](/docs/prysm-usage/database-backups). Briefly, the frequency at which you should perform backups really depends on your personal preference. If you want to perform backups once a day or once every week, ther is no harm nor bigger difference in doing so. Losing your beacon chain database is not a big deal aside from the fact that you will need to sync again from genesis. Losing your validator db can be problematic but if you wait several epochs before starting your validator, ensure your computer's clock is synced, the risk of slashing is low.
+The Prysm beacon node and validator allow performing database backups in case your machine gets corrupted and you need to restore it from some checkpoint. You can read our instructions on performing backups [here](/docs/prysm-usage/database-backups). Briefly, the frequency at which you should perform backups really depends on your personal preference. If you want to perform backups once a day or once every week, there is no harm nor bigger difference in doing so. Losing your beacon chain database is not a big deal aside from the fact that you will need to sync again from genesis. Losing your validator db can be problematic but if you wait several epochs before starting your validator, ensure your computer's clock is synced, the risk of slashing is low.
 
 #### Seeing a warning regarding binary signature not being trusted when downloading Prysm, should I be worried?
 
@@ -182,7 +182,7 @@ Prysm will soon implement the slashing protection [standard format](https://eips
 1. Turn off your beacon node and validator on machine 1, make sure it is not running as a system process. You can check this using the process monitor tools of your OS, or a command line tool such as top or htop and check for anything containing the name “prysm” “validator” or “beacon”
 2. Note the location of your wallet directory. If you used the default when you started Prysm, you can view its path at the top of the output of `validator accounts list`, which varies based on your operating system
 3. Take that entire directory and move it over to your next machine
-4. If you modified your validators’ — datadir, also migrate that directory to your next machine
+4. If you modified your validators’ `— datadir`, also migrate that directory to your next machine
 5. Wait at least a few epochs, sync your beacon node on your second machine, then start your validator client on your second machine
 6. Ensure you never run the same keys again on machine 1 or anywhere else
 
@@ -211,7 +211,7 @@ If you have a fully synced beacon node, you can fetch your account balance via t
 
 #### Why are some validators making a lot more money than others?
 
-If you look at the [validator leaderboard](https://beaconcha.in/validators/leaderboard), there are some validators at the top that seem to be doing a lot better than others. The reason being that either they (a) got lucky with being assigned to propse more blocks than other validators, or (b) they caught slashable offenses in the network and packed them into their blocks. Slashings are meant to be rare, and Prysm's slasher by default broadcasts slashings it finds to the network so that validators do not selfishly hold on to them. You can actually disable this to selfishly withhold slashings with the `--disable-broadcast-slasings` flag in your beacon node, although don't expect to get rich from slashing other validators. 
+If you look at the [validator leaderboard](https://beaconcha.in/validators/leaderboard), there are some validators at the top that seem to be doing a lot better than others. The reason being that either they (a) got lucky with being assigned to propose more blocks than other validators, or (b) they caught slashable offenses in the network and packed them into their blocks. Slashings are meant to be rare, and Prysm's slasher by default broadcasts slashings it finds to the network so that validators do not selfishly hold on to them. You can actually disable this to selfishly withhold slashings with the `--disable-broadcast-slashings` flag in your beacon node, although don't expect to get rich from slashing other validators. 
 
 Overall, keep in mind that no one has an extra advantage as a validator compared to others. Block proposal opportunities are random and it does not matter how powerful your hardware is. A lot of the times the validators near the top simply got lucky.
 

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -1,14 +1,13 @@
 ---
 id: faq
-title: Frequently asked questions
-sidebar_label: Frequently asked questions (FAQ)
+title: Prysm - Frequently asked questions
+sidebar_label: Frequently asked questions
 ---
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-
-## Frequently asked questions (FAQ)
+# Frequently asked questions
 
 ### Troubleshooting Prysm
 

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -1,14 +1,14 @@
 ---
 id: faq
 title: Frequently asked questions
-sidebar_label: Troubleshooting FAQ
+sidebar_label: Frequently asked questions (FAQ)
 ---
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 
-## Frequently asked questions
+## Frequently asked questions (FAQ)
 
 ### Troubleshooting Prysm
 

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -127,10 +127,6 @@
 				{
 					"type": "doc",
 					"id": "prysm-usage/p2p-host-ip"
-				},
-				{
-					"type": "doc",
-					"id": "faq"
 				}
 			]
 		},
@@ -303,6 +299,11 @@
 			"type": "doc",
 			"label": "Security Audits",
 			"id": "audits/phase0"
+		},
+		{
+			"type": "doc",
+			"id": "faq",
+			"label": "FAQ"
 		},
 		{
 			"type": "doc",

--- a/website/versioned_docs/version-2.1.0/faq.md
+++ b/website/versioned_docs/version-2.1.0/faq.md
@@ -1,39 +1,36 @@
 ---
 id: faq
-title: Frequently asked questions
+title: Prysm - Frequently asked questions
 sidebar_label: Frequently asked questions
 ---
-
-## Troubleshooting Prysm
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-#### Help, I see this error and don't know what it means!
+# Frequently asked questions
 
-If you have seen a scary ERROR log in your beacon node or validator, there are few things you should do first. Go to our [open issues](https://github.com/prysmaticlabs/prysm/issues) to see if someone has reported the same problem before. Otherwise, note the Prysm version you are running, your operating system, and file a bug report [here](https://github.com/prysmaticlabs/prysm/issues/new?assignees=&labels=&template=bug_report.md). You can also ask our community on [discord](https://discord.gg/prysmaticlabs) about your error and we will take a look as soon as possible.
+### Troubleshooting Prysm
+
+#### How do I troubleshoot errors?
+
+If your beacon node or validator logs display an `ERROR`, go to our [open issues](https://github.com/prysmaticlabs/prysm/issues) to see if someone has reported the same problem before. If this doesn't help, note the **Prysm version you're running** and your **operating system**, and then file a bug report [here](https://github.com/prysmaticlabs/prysm/issues/new?assignees=&labels=&template=bug_report.md). You can also ask our community on [discord](https://discord.gg/prysmaticlabs) about your error and we'll take a look as soon as possible.
 
 #### My validator is losing money, what's going on?
 
-If your validators are performing poorly and losing money, there are few pieces of information we need to help you out.
-
-**Things you can do**
-
-1. Check if your node or validator client crashed. You can view the logs of the process to see if there were any ERROR logs. If so, please file a bug report or talk to our team on [discord](https://discord.gg/prysmaticlabs). A fatal crash is quite serious and something we will investigate right away. You can try restarting your processes in the meantime to see if you can be fully operational again.
+1. Try restarting your machine and associated processes.
+1. See if your node or validator client crashed. You can view the logs of the process to see if there were any `ERROR` logs. If so, please file a bug report or talk to our team on [discord](https://discord.gg/prysmaticlabs). A fatal crash is quite serious and something we'll investigate right away.
 2. Check your network connectivity. You can improve this by following our tips [here](/docs/prysm-usage/p2p-host-ip) which can help you find better peers, improve attestation effectiveness, and more.
 3. Check your system resource usage, perhaps your node is using excess CPU and RAM. Depending on your operating system, there are different ways to do this.
 
-**Things we can do**
-
-If your issue has not yet been resolved, please do the following. Note your Prysm version and operating system, ensure none of the issues are above were the root cause of your problem, then reach out to our team on [Discord](https://discord.gg/prysmaticlabs). We need as much information about error logs or other issues you may be seeing to effectively answer your questions and get you back to validating correctly.
+If you still need help, note your **Prysm version** and **operating system**, and then reach out to our team on [Discord](https://discord.gg/prysmaticlabs). Providing as much information as possible will help us troubleshoot your issue.
 
 #### My node suddenly lost peers, what can I do?
 
 Losing peers can be due the following reasons:
 
 1. Your network connectivity has problems. You can check how to improve it with some of our tips [here](/docs/prysm-usage/p2p-host-ip).
-2. Prysm is using a ton of memory or system resources and perhaps you ran out of memory. Ensure you meet the minimum specifications for runnuing Prysm specified in our installation pages for your operating system.
-3. A bug in our software that can affect your p2p connectivity. It is known that certain versions have issues with peers on operating systems such as Windows, so you could try [downgrading](/docs/prysm-usage/staying-up-to-date) to see if your issue is resolved. If this is the case, talk to our team on [Discord](https://discord.gg/prysmaticlabs) letting us know you had this issue
+2. Prysm is using a ton of memory or system resources and perhaps you ran out of memory. Ensure you meet the minimum specifications for running Prysm specified in our installation pages for your operating system.
+3. A bug in our software that can affect your p2p connectivity. It is known that certain versions have issues with peers on operating systems such as Windows, so you could try [downgrading](/docs/prysm-usage/staying-up-to-date) to see if your issue is resolved. If this is the case, talk to our team on [Discord](https://discord.gg/prysmaticlabs) letting us know you had this issue.
 
 #### I have an issue in the web UI, getting errors, what can I do?
 
@@ -66,11 +63,11 @@ The most common way validators get slashed is by **running the same validator ke
 
 Our team prepared a blog post on [slashing prevention tips](https://medium.com/prysmatic-labs/eth2-slashing-prevention-tips-f6faa5025f50) you can read to avoid slashings in the future.
 
-## Running Prysm
+### Running Prysm
 
 #### How can I check my Prysm version?
 
-Depending on your installation method, there are different ways to verify your prysm version:
+Depending on your installation method, there are different ways to verify your Prysm version:
 
 <Tabs
   groupId="method"
@@ -100,7 +97,7 @@ prysm.bat beacon-chain --version
 </TabItem>
 <TabItem value="docker">
 
-If you are running using docker and the :stable tag for Prysm, stable will always point to our latest [release](https://github.com/prysmaticlabs/prysm/releases). Otherwise, you can run the command `docker ps` to see your running docker containers. The suffix of your image name after the colon is the version you are runnning.
+If you are running using docker and the :stable tag for Prysm, stable will always point to our latest [release](https://github.com/prysmaticlabs/prysm/releases). Otherwise, you can run the command `docker ps` to see your running docker containers. The suffix of your image name after the colon is the version you are running.
 
 ```
 CONTAINER ID        IMAGE                  COMMAND                  CREATED             STATUS              PORTS               NAMES
@@ -140,7 +137,7 @@ For help with running geth specifically, the [go-ethereum discord](https://disco
 
 #### How often should I perform database backups?
 
-The Prysm beacon node and validator allow performing database backups in case your machine gets corrupted and you need to restore it from some checkpoint. You can read our instructions on performing backups [here](/docs/prysm-usage/database-backups). Briefly, the frequency at which you should perform backups really depends on your personal preference. If you want to perform backups once a day or once every week, ther is no harm nor bigger difference in doing so. Losing your beacon chain database is not a big deal aside from the fact that you will need to sync again from genesis. Losing your validator db can be problematic but if you wait several epochs before starting your validator, ensure your computer's clock is synced, the risk of slashing is low.
+The Prysm beacon node and validator allow performing database backups in case your machine gets corrupted and you need to restore it from some checkpoint. You can read our instructions on performing backups [here](/docs/prysm-usage/database-backups). Briefly, the frequency at which you should perform backups really depends on your personal preference. If you want to perform backups once a day or once every week, there is no harm nor bigger difference in doing so. Losing your beacon chain database is not a big deal aside from the fact that you will need to sync again from genesis. Losing your validator db can be problematic but if you wait several epochs before starting your validator, ensure your computer's clock is synced, the risk of slashing is low.
 
 #### Seeing a warning regarding binary signature not being trusted when downloading Prysm, should I be worried?
 
@@ -168,7 +165,7 @@ Your node is running the popular [prometheus](https://prometheus.io/) server for
 
 Yes we currently support arm 64-bit architectures such as the raspberry pi 4 and they go out as part of our pre-compiled binary releases [here](https://github.com/prysmaticlabs/prysm/releases). Our documentation portal has instructions on how to run the entire installation process [here](/docs/install/install-with-script). However, we recommend using more powerful hardware in mainnet conditions. 
 
-## Validator keys and validator deposits
+### Validator keys and validator deposits
 
 #### I sent my deposit and so much time has passed but my validator is not active yet
 
@@ -185,7 +182,7 @@ Prysm will soon implement the slashing protection [standard format](https://eips
 1. Turn off your beacon node and validator on machine 1, make sure it is not running as a system process. You can check this using the process monitor tools of your OS, or a command line tool such as top or htop and check for anything containing the name “prysm” “validator” or “beacon”
 2. Note the location of your wallet directory. If you used the default when you started Prysm, you can view its path at the top of the output of `validator accounts list`, which varies based on your operating system
 3. Take that entire directory and move it over to your next machine
-4. If you modified your validators’ — datadir, also migrate that directory to your next machine
+4. If you modified your validators’ `— datadir`, also migrate that directory to your next machine
 5. Wait at least a few epochs, sync your beacon node on your second machine, then start your validator client on your second machine
 6. Ensure you never run the same keys again on machine 1 or anywhere else
 
@@ -203,11 +200,18 @@ Adding new validators to your already-running Prysm instance is quite simple! Go
 
 Please note you will need to **restart the validator client** after importing the new one for the changes to take effect.
 
-## Ethereum proof-of-stake specific questions
+### Ethereum proof-of-stake specific questions
+
+#### How do I check my current validator balance?
+The easiest way to check your current validator account balance is to search for your validator public key in a blockchain explorer like [beaconchai.in](https://beaconcha.in/).
+
+<!--todo: explain how -->
+If you have a fully synced beacon node, you can fetch your account balance via the beacon node API.
+
 
 #### Why are some validators making a lot more money than others?
 
-If you look at the [validator leaderboard](https://beaconcha.in/validators/leaderboard), there are some validators at the top that seem to be doing a lot better than others. The reason being that either they (a) got lucky with being assigned to propse more blocks than other validators, or (b) they caught slashable offenses in the network and packed them into their blocks. Slashings are meant to be rare, and Prysm's slasher by default broadcasts slashings it finds to the network so that validators do not selfishly hold on to them. You can actually disable this to selfishly withhold slashings with the `--disable-broadcast-slasings` flag in your beacon node, although don't expect to get rich from slashing other validators. 
+If you look at the [validator leaderboard](https://beaconcha.in/validators/leaderboard), there are some validators at the top that seem to be doing a lot better than others. The reason being that either they (a) got lucky with being assigned to propose more blocks than other validators, or (b) they caught slashable offenses in the network and packed them into their blocks. Slashings are meant to be rare, and Prysm's slasher by default broadcasts slashings it finds to the network so that validators do not selfishly hold on to them. You can actually disable this to selfishly withhold slashings with the `--disable-broadcast-slashings` flag in your beacon node, although don't expect to get rich from slashing other validators. 
 
 Overall, keep in mind that no one has an extra advantage as a validator compared to others. Block proposal opportunities are random and it does not matter how powerful your hardware is. A lot of the times the validators near the top simply got lucky.
 

--- a/website/versioned_sidebars/version-2.1.0-sidebars.json
+++ b/website/versioned_sidebars/version-2.1.0-sidebars.json
@@ -1,317 +1,307 @@
 {
-  "version-2.1.0/docs": [
-    {
-      "type": "doc",
-      "id": "version-2.1.0/getting-started"
-    },
-    {
-      "type": "category",
-      "collapsed": true,
-      "collapsible": true,
-      "label": "Installation Guide",
-      "items": [
-        {
-          "type": "doc",
-          "id": "version-2.1.0/install/install-with-script"
+    "version-2.1.0/docs": [{
+            "type": "doc",
+            "id": "version-2.1.0/getting-started"
         },
         {
-          "type": "doc",
-          "id": "version-2.1.0/install/install-with-docker"
+            "type": "category",
+            "collapsed": true,
+            "collapsible": true,
+            "label": "Installation Guide",
+            "items": [{
+                    "type": "doc",
+                    "id": "version-2.1.0/install/install-with-script"
+                },
+                {
+                    "type": "doc",
+                    "id": "version-2.1.0/install/install-with-docker"
+                },
+                {
+                    "type": "doc",
+                    "id": "version-2.1.0/install/install-with-bazel"
+                }
+            ]
         },
         {
-          "type": "doc",
-          "id": "version-2.1.0/install/install-with-bazel"
+            "type": "category",
+            "collapsed": true,
+            "collapsible": true,
+            "label": "Configuration Guide",
+            "items": [{
+                    "type": "doc",
+                    "id": "version-2.1.0/prysm-usage/parameters"
+                },
+                {
+                    "type": "doc",
+                    "id": "version-2.1.0/prysm-usage/staying-up-to-date"
+                },
+                {
+                    "type": "doc",
+                    "id": "version-2.1.0/prysm-usage/checkpoint-sync"
+                },
+                {
+                    "type": "doc",
+                    "id": "version-2.1.0/execution-node/fee-recipient"
+                },
+                {
+                    "type": "doc",
+                    "id": "version-2.1.0/prysm-usage/graffiti-file"
+                },
+                {
+                    "type": "doc",
+                    "id": "version-2.1.0/prysm-usage/database-backups"
+                },
+                {
+                    "type": "doc",
+                    "id": "version-2.1.0/prysm-usage/web-interface"
+                },
+                {
+                    "type": "doc",
+                    "id": "version-2.1.0/prysm-usage/secure-grpc"
+                },
+                {
+                    "type": "doc",
+                    "id": "version-2.1.0/prysm-usage/slasher"
+                },
+                {
+                    "type": "doc",
+                    "id": "version-2.1.0/prysm-usage/individual-validator-monitoring"
+                },
+                {
+                    "type": "doc",
+                    "id": "version-2.1.0/prysm-usage/monitoring/grafana-dashboard"
+                },
+                {
+                    "type": "doc",
+                    "id": "version-2.1.0/prysm-usage/client-stats"
+                }
+            ]
+        },
+        {
+            "type": "category",
+            "collapsed": true,
+            "collapsible": true,
+            "label": "Running an Execution Node",
+            "items": [{
+                    "type": "doc",
+                    "id": "version-2.1.0/execution-node/configuring-for-prysm"
+                },
+                {
+                    "type": "doc",
+                    "id": "version-2.1.0/execution-node/authentication"
+                }
+            ]
+        },
+        {
+            "type": "category",
+            "collapsed": true,
+            "collapsible": true,
+            "label": "Advanced Usage",
+            "items": [{
+                    "type": "doc",
+                    "id": "version-2.1.0/advanced/migrating-keys"
+                },
+                {
+                    "type": "doc",
+                    "id": "version-2.1.0/advanced/beacon_node_api"
+                }
+            ]
+        },
+        {
+            "type": "category",
+            "collapsed": true,
+            "collapsible": true,
+            "label": "Troubleshooting",
+            "items": [{
+                    "type": "doc",
+                    "id": "version-2.1.0/prysm-usage/is-everything-fine"
+                },
+                {
+                    "type": "doc",
+                    "id": "version-2.1.0/prysm-usage/p2p-host-ip"
+                }
+            ]
+        },
+        {
+            "type": "category",
+            "collapsed": true,
+            "collapsible": true,
+            "label": "Validator Key Management",
+            "items": [{
+                    "type": "doc",
+                    "id": "version-2.1.0/wallet/introduction"
+                },
+                {
+                    "type": "doc",
+                    "id": "version-2.1.0/wallet/deterministic"
+                },
+                {
+                    "type": "doc",
+                    "id": "version-2.1.0/wallet/nondeterministic"
+                },
+                {
+                    "type": "doc",
+                    "id": "version-2.1.0/wallet/web3signer"
+                },
+                {
+                    "type": "doc",
+                    "id": "version-2.1.0/wallet/remote"
+                },
+                {
+                    "type": "doc",
+                    "id": "version-2.1.0/wallet/slashing-protection"
+                },
+                {
+                    "type": "doc",
+                    "id": "version-2.1.0/wallet/exiting-a-validator"
+                }
+            ]
+        },
+        {
+            "type": "category",
+            "collapsed": true,
+            "collapsible": true,
+            "label": "API Usage",
+            "items": [{
+                    "type": "doc",
+                    "id": "version-2.1.0/how-prysm-works/ethereum-public-api"
+                },
+                {
+                    "type": "doc",
+                    "id": "version-2.1.0/how-prysm-works/prysm-public-api"
+                },
+                {
+                    "type": "doc",
+                    "id": "version-2.1.0/how-prysm-works/keymanager-api"
+                }
+            ]
+        },
+        {
+            "type": "category",
+            "collapsed": true,
+            "collapsible": true,
+            "label": "Developer Wiki",
+            "items": [{
+                    "type": "doc",
+                    "id": "version-2.1.0/devtools/init-state"
+                },
+                {
+                    "type": "doc",
+                    "id": "version-2.1.0/devtools/net-design"
+                },
+                {
+                    "type": "doc",
+                    "id": "version-2.1.0/devtools/api-middleware"
+                },
+                {
+                    "type": "doc",
+                    "id": "version-2.1.0/how-prysm-works/architecture-overview"
+                },
+                {
+                    "type": "doc",
+                    "id": "version-2.1.0/how-prysm-works/beacon-node"
+                },
+                {
+                    "type": "doc",
+                    "id": "version-2.1.0/how-prysm-works/prysm-validator-client"
+                },
+                {
+                    "type": "doc",
+                    "id": "version-2.1.0/how-prysm-works/validator-lifecycle"
+                },
+                {
+                    "type": "doc",
+                    "id": "version-2.1.0/how-prysm-works/validator-deposit-contract"
+                },
+                {
+                    "type": "doc",
+                    "id": "version-2.1.0/how-prysm-works/database-backend-boltdb"
+                },
+                {
+                    "type": "doc",
+                    "id": "version-2.1.0/how-prysm-works/p2p-networking"
+                },
+                {
+                    "type": "doc",
+                    "id": "version-2.1.0/how-prysm-works/bls-cryptography"
+                },
+                {
+                    "type": "doc",
+                    "id": "version-2.1.0/devtools/end-to-end"
+                }
+            ]
+        },
+        {
+            "type": "category",
+            "collapsed": true,
+            "collapsible": true,
+            "label": "Contribution Guidelines",
+            "items": [{
+                    "type": "doc",
+                    "id": "version-2.1.0/contribute/doc-standards"
+                },
+                {
+                    "type": "doc",
+                    "id": "version-2.1.0/contribute/contribution-guidelines"
+                },
+                {
+                    "type": "doc",
+                    "id": "version-2.1.0/contribute/bugreports"
+                },
+                {
+                    "type": "doc",
+                    "id": "version-2.1.0/contribute/golang-principles"
+                }
+            ]
+        },
+        {
+            "type": "category",
+            "collapsed": true,
+            "collapsible": true,
+            "label": "Miscellaneous",
+            "items": [{
+                    "type": "doc",
+                    "id": "version-2.1.0/terminology"
+                },
+                {
+                    "type": "doc",
+                    "id": "version-2.1.0/reading/eth2"
+                },
+                {
+                    "type": "doc",
+                    "id": "version-2.1.0/reading/golang"
+                },
+                {
+                    "type": "doc",
+                    "id": "version-2.1.0/reading/bazel"
+                },
+                {
+                    "type": "doc",
+                    "id": "version-2.1.0/reading/testnet-postmortems"
+                },
+                {
+                    "type": "doc",
+                    "id": "version-2.1.0/devtools/block-explorers"
+                }
+            ]
+        },
+        {
+            "type": "doc",
+            "label": "Security Best Practices",
+            "id": "version-2.1.0/security-best-practices"
+        },
+        {
+            "type": "doc",
+            "id": "version-2.1.0/audits/phase0"
+        },
+        {
+            "type": "doc",
+            "id": "faq",
+            "label": "FAQ"
+        },
+        {
+            "type": "doc",
+            "id": "version-2.1.0/licenses/prysmatic-labs"
         }
-      ]
-    },
-    {
-      "type": "category",
-      "collapsed": true,
-      "collapsible": true,
-      "label": "Configuration Guide",
-      "items": [
-        {
-          "type": "doc",
-          "id": "version-2.1.0/prysm-usage/parameters"
-        },
-        {
-          "type": "doc",
-          "id": "version-2.1.0/prysm-usage/staying-up-to-date"
-        },
-        {
-          "type": "doc",
-          "id": "version-2.1.0/prysm-usage/checkpoint-sync"
-        },
-        {
-          "type": "doc",
-          "id": "version-2.1.0/execution-node/fee-recipient"
-        },
-        {
-          "type": "doc",
-          "id": "version-2.1.0/prysm-usage/graffiti-file"
-        },
-        {
-          "type": "doc",
-          "id": "version-2.1.0/prysm-usage/database-backups"
-        },
-        {
-          "type": "doc",
-          "id": "version-2.1.0/prysm-usage/web-interface"
-        },
-        {
-          "type": "doc",
-          "id": "version-2.1.0/prysm-usage/secure-grpc"
-        },
-        {
-          "type": "doc",
-          "id": "version-2.1.0/prysm-usage/slasher"
-        },
-        {
-          "type": "doc",
-          "id": "version-2.1.0/prysm-usage/individual-validator-monitoring"
-        },
-        {
-          "type": "doc",
-          "id": "version-2.1.0/prysm-usage/monitoring/grafana-dashboard"
-        },
-        {
-          "type": "doc",
-          "id": "version-2.1.0/prysm-usage/client-stats"
-        }
-      ]
-    },
-    {
-      "type": "category",
-      "collapsed": true,
-      "collapsible": true,
-      "label": "Running an Execution Node",
-      "items": [
-        {
-          "type": "doc",
-          "id": "version-2.1.0/execution-node/configuring-for-prysm"
-        },
-        {
-          "type": "doc",
-          "id": "version-2.1.0/execution-node/authentication"
-        }
-      ]
-    },
-    {
-      "type": "category",
-      "collapsed": true,
-      "collapsible": true,
-      "label": "Advanced Usage",
-      "items": [
-        {
-          "type": "doc",
-          "id": "version-2.1.0/advanced/migrating-keys"
-        },
-        {
-          "type": "doc",
-          "id": "version-2.1.0/advanced/beacon_node_api"
-        }
-      ]
-    },
-    {
-      "type": "category",
-      "collapsed": true,
-      "collapsible": true,
-      "label": "Troubleshooting",
-      "items": [
-        {
-          "type": "doc",
-          "id": "version-2.1.0/prysm-usage/is-everything-fine"
-        },
-        {
-          "type": "doc",
-          "id": "version-2.1.0/prysm-usage/p2p-host-ip"
-        },
-        {
-          "type": "doc",
-          "id": "version-2.1.0/faq"
-        }
-      ]
-    },
-    {
-      "type": "category",
-      "collapsed": true,
-      "collapsible": true,
-      "label": "Validator Key Management",
-      "items": [
-        {
-          "type": "doc",
-          "id": "version-2.1.0/wallet/introduction"
-        },
-        {
-          "type": "doc",
-          "id": "version-2.1.0/wallet/deterministic"
-        },
-        {
-          "type": "doc",
-          "id": "version-2.1.0/wallet/nondeterministic"
-        },
-        {
-          "type": "doc",
-          "id": "version-2.1.0/wallet/web3signer"
-        },
-        {
-          "type": "doc",
-          "id": "version-2.1.0/wallet/remote"
-        },
-        {
-          "type": "doc",
-          "id": "version-2.1.0/wallet/slashing-protection"
-        },
-        {
-          "type": "doc",
-          "id": "version-2.1.0/wallet/exiting-a-validator"
-        }
-      ]
-    },
-    {
-      "type": "category",
-      "collapsed": true,
-      "collapsible": true,
-      "label": "API Usage",
-      "items": [
-        {
-          "type": "doc",
-          "id": "version-2.1.0/how-prysm-works/ethereum-public-api"
-        },
-        {
-          "type": "doc",
-          "id": "version-2.1.0/how-prysm-works/prysm-public-api"
-        },
-        {
-          "type": "doc",
-          "id": "version-2.1.0/how-prysm-works/keymanager-api"
-        }
-      ]
-    },
-    {
-      "type": "category",
-      "collapsed": true,
-      "collapsible": true,
-      "label": "Developer Wiki",
-      "items": [
-        {
-          "type": "doc",
-          "id": "version-2.1.0/devtools/init-state"
-        },
-        {
-          "type": "doc",
-          "id": "version-2.1.0/devtools/net-design"
-        },
-        {
-          "type": "doc",
-          "id": "version-2.1.0/devtools/api-middleware"
-        },
-        {
-          "type": "doc",
-          "id": "version-2.1.0/how-prysm-works/architecture-overview"
-        },
-        {
-          "type": "doc",
-          "id": "version-2.1.0/how-prysm-works/beacon-node"
-        },
-        {
-          "type": "doc",
-          "id": "version-2.1.0/how-prysm-works/prysm-validator-client"
-        },
-        {
-          "type": "doc",
-          "id": "version-2.1.0/how-prysm-works/validator-lifecycle"
-        },
-        {
-          "type": "doc",
-          "id": "version-2.1.0/how-prysm-works/validator-deposit-contract"
-        },
-        {
-          "type": "doc",
-          "id": "version-2.1.0/how-prysm-works/database-backend-boltdb"
-        },
-        {
-          "type": "doc",
-          "id": "version-2.1.0/how-prysm-works/p2p-networking"
-        },
-        {
-          "type": "doc",
-          "id": "version-2.1.0/how-prysm-works/bls-cryptography"
-        },
-        {
-          "type": "doc",
-          "id": "version-2.1.0/devtools/end-to-end"
-        }
-      ]
-    },
-    {
-      "type": "category",
-      "collapsed": true,
-      "collapsible": true,
-      "label": "Contribution Guidelines",
-      "items": [
-        {
-          "type": "doc",
-          "id": "version-2.1.0/contribute/doc-standards"
-        },
-        {
-          "type": "doc",
-          "id": "version-2.1.0/contribute/contribution-guidelines"
-        },
-        {
-          "type": "doc",
-          "id": "version-2.1.0/contribute/bugreports"
-        },
-        {
-          "type": "doc",
-          "id": "version-2.1.0/contribute/golang-principles"
-        }
-      ]
-    },
-    {
-      "type": "category",
-      "collapsed": true,
-      "collapsible": true,
-      "label": "Miscellaneous",
-      "items": [
-        {
-          "type": "doc",
-          "id": "version-2.1.0/terminology"
-        },
-        {
-          "type": "doc",
-          "id": "version-2.1.0/reading/eth2"
-        },
-        {
-          "type": "doc",
-          "id": "version-2.1.0/reading/golang"
-        },
-        {
-          "type": "doc",
-          "id": "version-2.1.0/reading/bazel"
-        },
-        {
-          "type": "doc",
-          "id": "version-2.1.0/reading/testnet-postmortems"
-        },
-        {
-          "type": "doc",
-          "id": "version-2.1.0/devtools/block-explorers"
-        }
-      ]
-    },
-    {
-			"type": "doc",
-			"label": "Security Best Practices",
-			"id": "version-2.1.0/security-best-practices"
-		},
-    {
-      "type": "doc",
-      "id": "version-2.1.0/audits/phase0"
-    },
-    {
-      "type": "doc",
-      "id": "version-2.1.0/licenses/prysmatic-labs"
-    }
-  ]
+    ]
 }

--- a/website/versioned_sidebars/version-2.1.0-sidebars.json
+++ b/website/versioned_sidebars/version-2.1.0-sidebars.json
@@ -296,7 +296,7 @@
         },
         {
             "type": "doc",
-            "id": "faq",
+            "id": "version-2.1.0/faq",
             "label": "FAQ"
         },
         {


### PR DESCRIPTION
This PR applies the following changes to vNext docs:

1. Move the FAQ out of the troubleshooting node and into the root of the TOC to improve discoverability, and to align more with the content since it's no longer a troubleshooting-only FAQ.
2. Some minor editorial improvements for a handful of questions - still needs work but I'm just boyscouting a bit
3. Add a question + answer about finding your account balance per @nisdas 

If we like how this feels as vNext, I'll pull into vCurrent and publish.