### PR TITLE
Getting started fix

### DIFF
--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -1,12 +1,25 @@
 ---
 id: getting-started
 title:  Prysm Ethereum Client Documentation
-sidebar_label: Get Started
+sidebar_label: Getting Started
 ---
 
-:::info
+## What is Prysm?
 
-This page has been replaced by our [Quickstart](./install/install-with-script).
+The [Prysm](https://github.com/prysmaticlabs/prysm) project is a full-featured implementation for the Ethereum proof-of-stake network written entirely in the [Go programming language](https://golang.org). Created by [Prysmatic Labs](https://prysmaticlabs.com), Prysm implements the official [Ethereum consensus specification](https://github.com/ethereum/consensus-specs), which is the product of an ongoing collective research and development effort by various teams across the Ethereum ecosystem including the [Ethereum Foundation](https://ethereum.org).
 
-:::
+## This documentation
 
+This manual is aimed at developers interested in participating in Ethereum consensus, which involves locking up a 32 ETH deposit to vote and produce blocks using our software. For more detailed information on the most recent research developments and understanding **what Ethereum consensus is**, it is recommended to review the official [Ethereum consensus specification](https://github.com/ethereum/consensus-specs) repository.
+
+## Communications
+
+Prysm has two official channels for release updates: our [Discord](https://discord.gg/prysmaticlabs) and our [mailing list](https://groups.google.com/g/prysm-dev). All releases will be notified via those channels.
+
+## Staking in Ethereum
+
+To participate in the Ethereum network as a validator in proof-of-stake, read our comprehensive guidelines [here](/docs/install/install-with-script).
+
+## Need assistance?
+
+If you have questions about this documentation, feel free to stop by either the [Prysmatic Discord](https://discord.gg/prysmaticlabs)'s **#documentation** channel and a member of the team or our community will be happy to assist you.

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -1,5 +1,10 @@
 {
-    "docs": [{
+    "docs": [
+        {
+            "type": "doc",
+            "id": "getting-started"
+        },
+        {
             "type": "doc",
             "label": "Quickstart",
             "id": "install/install-with-script"
@@ -14,7 +19,8 @@
             "collapsed": true,
             "collapsible": true,
             "label": "Installation Guide",
-            "items": [{
+            "items": [
+                {
                     "type": "doc",
                     "id": "install/install-with-docker"
                 },
@@ -29,7 +35,8 @@
             "collapsed": true,
             "collapsible": true,
             "label": "Configuration Guide",
-            "items": [{
+            "items": [
+                {
                     "type": "doc",
                     "id": "prysm-usage/parameters"
                 },
@@ -77,7 +84,6 @@
                     "type": "doc",
                     "id": "prysm-usage/client-stats"
                 }
-
             ]
         },
         {
@@ -85,7 +91,8 @@
             "collapsed": true,
             "collapsible": true,
             "label": "Running an Execution Node",
-            "items": [{
+            "items": [
+                {
                     "type": "doc",
                     "id": "execution-node/configuring-for-prysm"
                 },
@@ -100,7 +107,8 @@
             "collapsed": true,
             "collapsible": true,
             "label": "Advanced Usage",
-            "items": [{
+            "items": [
+                {
                     "type": "doc",
                     "id": "advanced/migrating-keys"
                 },
@@ -115,7 +123,8 @@
             "collapsed": true,
             "collapsible": true,
             "label": "Troubleshooting",
-            "items": [{
+            "items": [
+                {
                     "type": "doc",
                     "id": "prysm-usage/is-everything-fine"
                 },
@@ -130,7 +139,8 @@
             "collapsed": true,
             "collapsible": true,
             "label": "Validator Key Management",
-            "items": [{
+            "items": [
+                {
                     "type": "doc",
                     "id": "wallet/introduction"
                 },
@@ -165,7 +175,8 @@
             "collapsed": true,
             "collapsible": true,
             "label": "API Usage",
-            "items": [{
+            "items": [
+                {
                     "type": "doc",
                     "id": "how-prysm-works/ethereum-public-api"
                 },
@@ -177,7 +188,6 @@
                     "type": "doc",
                     "id": "how-prysm-works/keymanager-api"
                 }
-
             ]
         },
         {
@@ -185,7 +195,8 @@
             "collapsed": true,
             "collapsible": true,
             "label": "Developer Wiki",
-            "items": [{
+            "items": [
+                {
                     "type": "doc",
                     "id": "devtools/init-state"
                 },
@@ -240,7 +251,8 @@
             "collapsed": true,
             "collapsible": true,
             "label": "Contribution Guidelines",
-            "items": [{
+            "items": [
+                {
                     "type": "doc",
                     "id": "contribute/doc-standards"
                 },
@@ -263,7 +275,8 @@
             "collapsed": true,
             "collapsible": true,
             "label": "Miscellaneous",
-            "items": [{
+            "items": [
+                {
                     "type": "doc",
                     "id": "terminology"
                 },


### PR DESCRIPTION
This PR reintroduces the "Getting Started" content. It was originally removed as part of the vNext quickstart, but navigating to vNext from vCurrent Getting Started results in the sidebar disappearing. 

We recently aligned on keeping this page within vNext and turning it into a more informative / beginner-friendly introduction to Prysm. So this file will remain - content will change after vNext is published as vCurrent.