### PR TITLE
Removing documentation standards from sidebar

### DIFF
--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -299,10 +299,6 @@
             "items": [
                 {
                     "type": "doc",
-                    "id": "contribute/doc-standards"
-                },
-                {
-                    "type": "doc",
                     "id": "contribute/contribution-guidelines"
                 },
                 {


### PR DESCRIPTION
This page no longer reflects our content patterns and standards. Removing from sidebar for now - will remove file entirely when serverside redirects are configured. 

We don't get much contribution volume for docs - we can help contributions snap to standards on a case-by-case basis, and we can publish our latest standards when there's demand for them.