### PR TITLE
JWT clarifications

### DIFF
--- a/website/docs/install/install-with-script.md
+++ b/website/docs/install/install-with-script.md
@@ -109,7 +109,6 @@ First, create a folder called `ethereum` on your SSD, and then two subfolders wi
     <p>Navigate to your <code>consensus</code> directory and run the following commands:</p>
 
 ```
-SET USE_PRYSM_VERSION=v2.1.4-rc.1
 mkdir prysm && cd prysm
 curl https://raw.githubusercontent.com/prysmaticlabs/prysm/master/prysm.bat --output prysm.bat
 reg add HKCU\Console /v VirtualTerminalLevel /t REG_DWORD /d 1
@@ -121,7 +120,6 @@ reg add HKCU\Console /v VirtualTerminalLevel /t REG_DWORD /d 1
     <p>Navigate to your <code>consensus</code> directory and run the following commands:</p>
 
 ```
-USE_PRYSM_VERSION=v2.1.4-rc.1
 mkdir prysm && cd prysm
 curl https://raw.githubusercontent.com/prysmaticlabs/prysm/master/prysm.sh --output prysm.sh && chmod +x prysm.sh
 ```

--- a/website/docs/partials/_jwt-generation-partial.md
+++ b/website/docs/partials/_jwt-generation-partial.md
@@ -1,7 +1,7 @@
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-The HTTP connection between your beacon node and execution node needs to be authenticated using a [JWT token](https://jwt.io/). There are several ways to generate this JWT token:
+The HTTP connection between your beacon node and execution node needs to be authenticated using a [JWT token](https://jwt.io/) if you're using a testnet. JWT authentication will soon be required on Mainnet. There are several ways to generate this JWT token:
 
  - Use an online generator like [this](https://seanwasere.com/generate-random-hex/). Copy and paste this value into a `jwt.hex` file.
  - Use a utility like OpenSSL to create the token via command: `openssl rand -hex 32 | tr -d "\n" > "jwt.hex"`.

--- a/website/docs/partials/_jwt-generation-partial.md
+++ b/website/docs/partials/_jwt-generation-partial.md
@@ -1,7 +1,7 @@
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-The HTTP connection between your beacon node and execution node needs to be authenticated using a [JWT token](https://jwt.io/) if you're using a testnet. JWT authentication will soon be required on Mainnet. There are several ways to generate this JWT token:
+If you're using a testnet (like Goerli-Prater, Ropsten, or Sepolia) the HTTP connection between your beacon node and execution node needs to be authenticated using a [JWT token](https://jwt.io/). There are several ways to generate this JWT token:
 
  - Use an online generator like [this](https://seanwasere.com/generate-random-hex/). Copy and paste this value into a `jwt.hex` file.
  - Use a utility like OpenSSL to create the token via command: `openssl rand -hex 32 | tr -d "\n" > "jwt.hex"`.

--- a/website/docs/partials/_jwt-generation-partial.md
+++ b/website/docs/partials/_jwt-generation-partial.md
@@ -6,7 +6,7 @@ If you're using a testnet (like Goerli-Prater, Ropsten, or Sepolia) the HTTP con
  - Use an online generator like [this](https://seanwasere.com/generate-random-hex/). Copy and paste this value into a `jwt.hex` file.
  - Use a utility like OpenSSL to create the token via command: `openssl rand -hex 32 | tr -d "\n" > "jwt.hex"`.
  - Use an execution client to generate the `jwt.hex` file.
- - Use Prysm to generate the `jwt.hex` file:
+ - Use Prysm [v2.1.3-rc.1](https://github.com/prysmaticlabs/prysm/releases/tag/v2.1.4-rc.1) to generate the `jwt.hex` file:
 
 <Tabs groupId="os" defaultValue="others" values={[
     {label: 'Windows', value: 'win'},

--- a/website/docs/vNext/214-rc.md
+++ b/website/docs/vNext/214-rc.md
@@ -7,7 +7,7 @@ sidebar_label: Use Prysm v2.1.4-rc.1 to Merge-test Goerli-Prater
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-[Prysm v2.1.4-rc.1](https://github.com/prysmaticlabs/prysm/releases/tag/v2.1.4-rc.1) can be used to run a node on Goerli-Prater using Merge-ready configuration. If you'd like to Merge-test the Goerli-Prater [network pair](../concepts/nodes-networks.md), use  either of the following guides to configure your node (and optionally, your validator):
+[Prysm v2.1.4-rc.1](https://github.com/prysmaticlabs/prysm/releases/tag/v2.1.4-rc.1) can be used to run a node on Goerli-Prater using Merge-ready configuration. If you'd like to Merge-test the Goerli-Prater [network pair](../concepts/nodes-networks.md), use either of the following guides to configure your node (and optionally, your validator):
 
  - [Quickstart](../install/install-with-script.md): For users who are starting from scratch.
  - [Prepare for The Merge](../prepare-for-merge.md): For users who are already running a node.


### PR DESCRIPTION
 - Updates embeddable JWT guidance to clarify that JWT is only needed if you're not running on Mainnet.
 - Removes duplicated environment variable step from quickstart.