### PR TITLE
Add contract-deployment-block flag

### DIFF
--- a/website/docs/advanced/proof-of-stake-devnet.md
+++ b/website/docs/advanced/proof-of-stake-devnet.md
@@ -215,7 +215,8 @@ This will out a file `genesis.ssz` in your `devnet` folder. Now, run the Prysm b
       --chain-id=32382 \
       --execution-endpoint=http://localhost:8551 \
       --accept-terms-of-use \
-      --jwt-secret=gethdata/geth/jwtsecret
+      --jwt-secret=gethdata/geth/jwtsecret \
+      --contract-deployment-block=0
     
 
 and the Prysm validator client soon after:


### PR DESCRIPTION
Add the `contract-deployment-block=0` to the guide as requested in the DC local setup discussion [here](https://discord.com/channels/476244492043812875/560308336248225812/1092729846876082258).