### PR TITLE
Update _quickstart-run-execution-node.md

### DIFF
--- a/website/docs/install/partials/_quickstart-run-execution-node.md
+++ b/website/docs/install/partials/_quickstart-run-execution-node.md
@@ -112,8 +112,8 @@ import TabItem from '@theme/TabItem';
             {label: 'JWT', value: 'jwt'},
             {label: 'IPC', value: 'ipc'}
             ]}>
-                <TabItem value="jwt"><pre><code>geth --sepolia --http --http.api eth,net,engine,admin --authrpc.jwtsecret /path/to/jwt.hex --override.terminaltotaldifficulty 17000000000000000</code></pre></TabItem>
-                <TabItem value="ipc"><pre><code>geth --sepolia --http --http.api eth,net,engine,admin --override.terminaltotaldifficulty 17000000000000000</code></pre></TabItem>
+                <TabItem value="jwt"><pre><code>geth --sepolia --http --http.api eth,net,engine,admin --authrpc.jwtsecret /path/to/jwt.hex</code></pre></TabItem>
+                <TabItem value="ipc"><pre><code>geth --sepolia --http --http.api eth,net,engine,admin</code></pre></TabItem>
             </Tabs>
       </TabItem>
     </Tabs>


### PR DESCRIPTION

Amend the document.

Removed the parameter in the geth command to execute the sepolia chain  "-- override.terminaltotaldifficulty 17000000000000000". 

The new version(1.11.6) of geth removes the "override.terminaltotaldifficulty" flag.  

Without the  "-- override.terminaltotaldifficulty 17000000000000000", geth can directly execute the sepolia test chain.