### PR TITLE
enh(validator-lifecycle): clarify eek and drop double spaces

### DIFF
--- a/website/docs/how-prysm-works/validator-lifecycle.md
+++ b/website/docs/how-prysm-works/validator-lifecycle.md
@@ -8,7 +8,7 @@ import {HeaderBadgesWidget} from '@site/src/components/HeaderBadgesWidget.js';
 
 <HeaderBadgesWidget />
 
-This section discusses the  lifecycle of a [validator](validator-clients.md) as defined by [Ethereum consensus specifications](https://github.com/ethereum/consensus-specs).
+This section discusses the lifecycle of a [validator](validator-clients.md) as defined by [Ethereum consensus specifications](https://github.com/ethereum/consensus-specs).
 
 ![Validator Lifecycle Diagram](/img/validator-lifecycle.png)
 
@@ -24,7 +24,7 @@ The current specification for [processing deposits](https://github.com/ethereum/
 
 ## ACTIVE State
 
-Once the activation epoch arrives, the validator is activated and assigned responsibilities including [proposing](/docs/terminology#propose) or [attesting](/docs/terminology#attest) to blocks on the beacon chain.  Validators  receive either rewards or penalties to the initial deposit based upon their overall performance.  If a validator's balance drops below 16 ETH (typically due to inactivity), it will be ejected.  Ejections are treated the same as a voluntary exits.
+Once the activation epoch arrives, the validator is activated and assigned responsibilities including [proposing](/docs/terminology#propose) or [attesting](/docs/terminology#attest) to blocks on the beacon chain. Validators receive either rewards or penalties to the initial deposit based upon their overall performance. If a validator's balance drops below 16 ETH (typically due to inactivity), it will be ejected. Ejections are treated the same as a voluntary exits.
 
 ## Withdrawals
 
@@ -34,16 +34,14 @@ Validators that have been active and have a validator index (including validator
 An ACTIVE validator may request to exit by submitting a signed [VoluntaryExit](https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#voluntary-exits) operation to the Ethereum network. Assuming the validator has been in the active state for the `SHARD_COMMITTEE_PERIOD`or 256 epochs ~ 27 hours plus the look ahead 4~5 epochs(~31 minutes), the validator will be assigned an exit_epoch that is determined by the length of the exiting queue. The beacon chain can process the exits of 4 ~ 16 validators per finalized epoch, the difference in the number is determined by the number of total active validators on the chain.
 
 ## SLASHING State
-If a slashable event is included in a block while a validator is either ACTIVE, EXITING, or EXITED, it will briefly enter the SLASHING state where slashing penalties are applied, before being forcefully transitioned into the EXITED state.  Slashed validators incur three distinct penalties:
+If a slashable event is included in a block while a validator is either ACTIVE, EXITING, or EXITED, it will briefly enter the SLASHING state where slashing penalties are applied, before being forcefully transitioned into the EXITED state. Slashed validators incur three distinct penalties:
   #### [Minimum Penalty](https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#slash_validator) 
   A penalty of (1/32 * Effective Balance), issued immediately
   #### [Missed Attestation Penalties](https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#rewards-and-penalties-1)
   A penalty equivalent to that incurred by an inactive validator, issued every epoch until the validator leaves the exit queue
   #### [Attack Multiplier Penalty](https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#slashings)
-  A penalty proportional to three times the number of other slashings in the past 8192 epochs (4 eeks, ~36 days), applied 4096 epochs (2 eeks, ~18 days) after the slashing event was first included in a block.  Under normal circumstances this penalty is quite small, however in the event that a large number of slashings occur in a short time frame, this penalty can be as high as 32 ETH.
+  A penalty proportional to three times the number of other slashings in the past 8192 epochs (4 <abbr title="An eek is a period of 2048 epochs (~9.1 days), it is short for Ethereum week">eeks</abbr>, ~36 days), applied 4096 epochs (2 eeks, ~18 days) after the slashing event was first included in a block. Under normal circumstances this penalty is quite small, however in the event that a large number of slashings occur in a short time frame, this penalty can be as high as 32 ETH.
 
 ## EXITED State
-In the case that the validator has reached the exited state voluntarily, the funds will become withdrawable after 256 epochs (~27 hours).  If the validator was slashed, this delay is extended to 4 eeks (2048 epochs*4 or ~36 days).  If a slashable event is included in a block before funds have been withdrawn, the validator will move back to the SLASHING state causing withdrawal delays to reset.
+In the case that the validator has reached the exited state voluntarily, the funds will become withdrawable after 256 epochs (~27 hours). If the validator was slashed, this delay is extended to 4 eeks (2048 epochs*4 or ~36 days). If a slashable event is included in a block before funds have been withdrawn, the validator will move back to the SLASHING state causing withdrawal delays to reset.
 > **NOTICE:** Funds will not be able to be withdrawn from validators until transactions are introduced after Ethereum proof-of-stake merges with the current Ethereum chain
-
-


### PR DESCRIPTION
I think clarifying what an eek is would be helpful. As I was updating the page, I found that there are double spaces here and there, I think this may be a typo so I updated the page for this as well.