### PR TITLE
Improve quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Below are steps for initialising and reproducing this portal for development.
 ## Installation
 
 1. Clone this repository.
-2.  Enter the newly cloned repo and enter the ` website` directory.
+2. Enter the newly cloned repo and enter the `website` directory.
 3. Issue the command `npm install`
 4. Wait for the installation process to complete.
 

--- a/website/docs/concepts/nodes-networks.md
+++ b/website/docs/concepts/nodes-networks.md
@@ -91,12 +91,12 @@ Every network's execution layer works with (and only with) its corresponding "pa
     <tr>
       <td>Goerli</td>
       <td>Prater</td>
-      <td>The Goerli-Prater pair is the test network that most people use when learning how to configure their validator for the first time. After Sepolia, Goerli-Prater will be Merge-tested.<br/><br/>This network pair mints and manages <strong>Goerli ETH</strong>, a type of testnet ETH used exclusively within this network pair.</td>
+      <td>The Goerli is the test network that most people use when learning how to configure their validator for the first time.<br/><br/>This network mints and manages <strong>Goerli ETH</strong>, a type of testnet ETH used exclusively within this network.</td>
     </tr>
     <tr>
       <td>Sepolia</td>
       <td>Sepolia</td>
-      <td>Consensus-layer Sepolia is a new network that was created to facilitate testing. The <a href='../install/install-with-script'>Prysm Quickstart</a> shows you how to configure a Merge-ready node on Sepolia. Note that this is a permissioned network, so you can run a node on Sepolia, but not a validator.<br/><br/>This network pair mints and manages <strong>SepplETH</strong>, a type of testnet ETH used exclusively within this network pair.</td>
+      <td>Sepolia is a network that was created to facilitate testing. The <a href='../install/install-with-script'>Prysm Quickstart</a> shows you how to configure a node on Sepolia. Note that this is a permissioned network, so you can run a node on Sepolia, but not a validator.<br/><br/>This network pair mints and manages <strong>SepplETH</strong>, a type of testnet ETH used exclusively within this network pair.</td>
     </tr>
     <tr>
       <td>Holesky</td>

--- a/website/docs/concepts/nodes-networks.md
+++ b/website/docs/concepts/nodes-networks.md
@@ -79,27 +79,22 @@ Every network's execution layer works with (and only with) its corresponding "pa
 
 <table>
     <tr>
-        <th style={{minWidth: 160 + 'px'}}>EL network</th> 
-        <th style={{minWidth: 160 + 'px'}}>CL network</th>
+        <th style={{minWidth: 160 + 'px'}}>network</th> 
         <th>Description</th>
     </tr>
     <tr>
-      <td>Mainnet</td>
       <td>Mainnet</td>
       <td>When people refer to Ethereum, they're usually referring to Ethereum Mainnet, which refers to a pair of networks: execution-layer (EL) Mainnet and consensus-layer (CL) Mainnet. CL Mainnet is commonly referred to as the Beacon Chain.<br/><br/>This network pair mints and manages real <strong>ETH</strong>.</td>
     </tr> 
     <tr>
       <td>Goerli</td>
-      <td>Prater</td>
-      <td>The Goerli is the test network that most people use when learning how to configure their validator for the first time.<br/><br/>This network mints and manages <strong>Goerli ETH</strong>, a type of testnet ETH used exclusively within this network.</td>
+      <td>Goerli is a network that was created to protocol and staking testing. Most people use it when learning how to configure their validator for the first time. In some places, you may read the term <strong>Goerli-Prater</strong> instead of <strong>Goerli</strong>. Pre-merge, for this network, the name of the execution layer was <strong>Goerli</strong>, and the name of the consensus layer was <strong>Prater</strong>. Post merge, the name <strong>Prater</strong> was deprecated and only <strong>Goerli</strong> remains.<br/><br/>This network mints and manages <strong>Goerli ETH</strong>, a type of testnet ETH used exclusively within this network.<br/><br/><strong>Warning: </strong> The Goerli network is intended to be deprecated in 2024. If you consider staking on a test network, please use Holesky. </td>
     </tr>
     <tr>
       <td>Sepolia</td>
-      <td>Sepolia</td>
-      <td>Sepolia is a network that was created to facilitate testing. The <a href='../install/install-with-script'>Prysm Quickstart</a> shows you how to configure a node on Sepolia. Note that this is a permissioned network, so you can run a node on Sepolia, but not a validator.<br/><br/>This network pair mints and manages <strong>SepplETH</strong>, a type of testnet ETH used exclusively within this network pair.</td>
+      <td>Sepolia is a network that was created to smart contract testing. The <a href='../install/install-with-script'>Prysm Quickstart</a> shows you how to configure a node on Sepolia. Note that this is a permissioned network, so you can run a node on Sepolia, but not a validator.<br/><br/>This network pair mints and manages <strong>Sepolia ETH</strong>, a type of testnet ETH used exclusively within this network pair.</td>
     </tr>
     <tr>
-      <td>Holesky</td>
       <td>Holesky</td>
       <td>Holesky is a merged-from-genesis public Ethereum testnet which will replace Goerli as a
       staking, infrastructure, and protocol-developer testnet. This network is primarily focused on

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -9,7 +9,7 @@ import {HeaderBadgesWidget} from '@site/src/components/HeaderBadgesWidget.js';
 <HeaderBadgesWidget commaDelimitedContributors="Clarin,Mick" />
 
 
-[Prysm](https://github.com/prysmaticlabs/prysm) is an [Ethereum](https://ethereum.org/en/developers/docs/intro-to-ethereum/) [proof-of-stake](https://ethereum.org/en/developers/docs/consensus-mechanisms/pos/) client written in [Go](https://golang.org). You can use Prysm to participate in Ethereum's [decentralized economy](https://ethereum.org/en/developers/docs/web2-vs-web3/) by [running a node](./install/install-with-script.md) and, if you have [32 ETH to stake](https://ethereum.org/en/staking/), a [validator](./install/install-with-script.md#step-6-run-a-validator-using-prysm). If you're new to Ethereum, you may enjoy our beginner-friendly [Nodes and networks](./concepts/nodes-networks.md) explainer.
+[Prysm](https://github.com/prysmaticlabs/prysm) is an [Ethereum](https://ethereum.org/en/developers/docs/intro-to-ethereum/) [proof-of-stake](https://ethereum.org/en/developers/docs/consensus-mechanisms/pos/) client written in [Go](https://golang.org). You can use Prysm to participate in Ethereum's [decentralized economy](https://ethereum.org/en/developers/docs/web2-vs-web3/) by [running a node](./install/install-with-script.md) and, if you have [32 ETH to stake](https://ethereum.org/en/staking/), a [validator client](./install/install-with-script.md#step-6-run-a-validator-using-prysm). If you're new to Ethereum, you may enjoy our beginner-friendly [Nodes and networks](./concepts/nodes-networks.md) explainer.
 
 The following table of contents provides a descriptive overview of Prysm's documentation:
 

--- a/website/docs/install/install-with-bazel.md
+++ b/website/docs/install/install-with-bazel.md
@@ -124,7 +124,7 @@ import MultidimensionalContentControlsPartial from '@site/docs/partials/_multidi
 
 <Tabs groupId="network" defaultValue="mainnet" values={[
         {label: 'Mainnet', value: 'mainnet'},
-        {label: 'Goerli-Prater', value: 'goerli-prater'},
+        {label: 'Goerli', value: 'goerli'},
         {label: 'Sepolia', value: 'sepolia'},
         {label: 'Holesky', value: 'holesky'}
     ]}>
@@ -135,9 +135,9 @@ bazel run //beacon-chain --config=release -- --execution-endpoint=<YOUR_ETH_EXEC
 ```
 
   </TabItem>
-      <TabItem value="goerli-prater">
+      <TabItem value="goerli">
 
-Download the Goerli-Prater genesis state from [Github](https://github.com/eth-clients/eth2-networks/raw/master/shared/prater/genesis.ssz) to a local file. Then issue the following command:
+Download the Goerli genesis state from [Github](https://github.com/eth-clients/eth2-networks/raw/master/shared/prater/genesis.ssz) to a local file. Then issue the following command:
 
 ```text
 bazel run //beacon-chain --config=release -- --execution-endpoint=<YOUR_ETH_EXECUTION_NODE_ENDPOINT> --prater --genesis-state=/path/to/genesis.ssz
@@ -173,7 +173,7 @@ bazel run //beacon-chain --config=release -- --execution-endpoint=<YOUR_ETH_EXEC
 
 Ensure that your beacon node is fully synced before proceeding. See [Check node and validator status](../monitoring/checking-status.md) for detailed status-checking instructions.
 
-Navigate to the [Mainnet Launchpad](https://launchpad.ethereum.org/summary) and follow the instructions. If you want to participate in the **testnet**, you can navigate to the [Goerli-Prater](https://goerli.launchpad.ethereum.org/summary/).
+Navigate to the [Mainnet Launchpad](https://launchpad.ethereum.org/summary) and follow the instructions. If you want to participate in the **testnet**, you can navigate to the [Goerli](https://goerli.launchpad.ethereum.org/summary/).
 
 :::danger Exercise extreme caution
 

--- a/website/docs/install/install-with-docker.md
+++ b/website/docs/install/install-with-docker.md
@@ -116,7 +116,7 @@ Next, use Docker to tell your beacon node to connect to your local execution nod
 
 <Tabs groupId="network" defaultValue="mainnet" values={[
         {label: 'Mainnet', value: 'mainnet'},
-        {label: 'Goerli-Prater', value: 'goerli-prater'},
+        {label: 'Goerli', value: 'goerli'},
         {label: 'Sepolia', value: 'sepolia'}
     ]}>
       <TabItem value="mainnet">
@@ -133,9 +133,9 @@ docker run -it -v $HOME/.eth2:/data -p 4000:4000 -p 13000:13000 -p 12000:12000/u
 ```
 
   </TabItem>
-      <TabItem value="goerli-prater">
+      <TabItem value="goerli">
 
-Download the Goerli-Prater genesis state from [Github](https://github.com/eth-clients/eth2-networks/raw/master/shared/prater/genesis.ssz) to a local file. Then issue the following command:
+Download the Goerli genesis state from [Github](https://github.com/eth-clients/eth2-networks/raw/master/shared/prater/genesis.ssz) to a local file. Then issue the following command:
 
 ```text
 docker run -it -v $HOME/.eth2:/data -v /path/to/genesis.ssz:/genesis/genesis.ssz -p 4000:4000 -p 13000:13000 -p 12000:12000/udp --name beacon-node \
@@ -181,7 +181,7 @@ To ensure that your Docker image has access to a data directory, mount a local d
 
 <Tabs groupId="network" defaultValue="mainnet" values={[
         {label: 'Mainnet', value: 'mainnet'},
-        {label: 'Goerli-Prater', value: 'goerli-prater'},
+        {label: 'Goerli', value: 'goerli'},
         {label: 'Sepolia', value: 'sepolia'}
     ]}>
       <TabItem value="mainnet">
@@ -191,9 +191,9 @@ docker run -it -v %LOCALAPPDATA%\Eth2:/data -p 4000:4000 -p 13000:13000 -p 12000
 ```
 
   </TabItem>
-      <TabItem value="goerli-prater">
+      <TabItem value="goerli">
 
-Download the Goerli-Prater genesis state from [Github](https://github.com/eth-clients/eth2-networks/raw/master/shared/prater/genesis.ssz) to a local file. Then issue the following command:
+Download the Goerli genesis state from [Github](https://github.com/eth-clients/eth2-networks/raw/master/shared/prater/genesis.ssz) to a local file. Then issue the following command:
 
 ```text
 docker run -it -v %LOCALAPPDATA%\Eth2:/data -v \path\to\genesis.ssz:/genesis/genesis.ssz -p 4000:4000 -p 13000:13000 -p 12000:12000/udp gcr.io/prysmaticlabs/prysm/beacon-chain:stable --datadir=/data --jwt-secret=<YOUR_JWT_SECRET> --rpc-host=0.0.0.0 --grpc-gateway-host=0.0.0.0 --monitoring-host=0.0.0.0 --execution-endpoint=<YOUR_ETH_EXECUTION_NODE_ENDPOINT> --genesis-state=/genesis/genesis.ssz --prater
@@ -253,7 +253,7 @@ The Ethereum launchpad URL is `https://launchpad.ethereum.org` and the only, off
 
 :::
 
-Use the [Mainnet Launchpad](https://launchpad.ethereum.org/summary) to deposit your 32 ETH. If you want to participate in the **testnet**, use the [Goerli-Prater](https://goerli.launchpad.ethereum.org/en/) launchpad.
+Use the [Mainnet Launchpad](https://launchpad.ethereum.org/summary) to deposit your 32 ETH. If you want to participate in the **testnet**, use the [Goerli](https://goerli.launchpad.ethereum.org/en/) launchpad.
 
 Throughout the process, you'll be asked to generate new validator credentials using the [official Ethereum deposit command-line-tool](https://github.com/ethereum/eth2.0-deposit-cli). Make sure you use the `mainnet` option when generating keys with the deposit CLI. During the process, you will have generated a `validator_keys` folder under the `eth2.0-deposit-cli` directory. You can import all of your validator keys into Prysm from that folder in the next step.
 

--- a/website/docs/install/install-with-script.md
+++ b/website/docs/install/install-with-script.md
@@ -40,8 +40,6 @@ import QuickstartRunExecutionNodeJWTPartial from '@site/docs/install/partials/_q
 
 <QuickstartRunExecutionNodeJWTPartial />
 
-Congratulations - you’re now running an <strong>execution node</strong> in Ethereum’s execution layer.
-
 ## Step 4: Run a beacon node using Prysm
 
 import QuickstartRunBeaconNodePartial from '@site/docs/install/partials/_quickstart-run-beacon-node.md';
@@ -122,7 +120,7 @@ Yes - you can use [checkpoint sync](https://docs.prylabs.network/docs/prysm-usag
 This is usually an indication that your validator isn't able to communicate with your beacon node, or your beacon node isn't able to connect to your execution node.
 
 **How long does it take for my validator to be selected to propose a new block?** <br />
-At the time of this writing, a ballpark estimate is **around a week**. Every 12 seconds a new block is proposed, and your validator has a one in [total number of active validators] chance of being chosen, so this duration can vary significantly from one validator to the next.
+At the time of this writing, a ballpark estimate is **around every four months** on mainnet. Every 12 seconds a new block is proposed, and your validator has a one in [total number of active validators] chance of being chosen, so this duration can vary significantly from one validator to the next.
 
 <!-- **Can I run a full node and validator client on a Raspberry Pi?** <br />
 TODO

--- a/website/docs/install/partials/_quickstart-install-prysm.md
+++ b/website/docs/install/partials/_quickstart-install-prysm.md
@@ -17,7 +17,6 @@ Create a folder called `ethereum` on your SSD, and then two subfolders within it
     <p>Navigate to your <code>consensus</code> directory and run the following commands:</p>
 
 ```
-mkdir prysm && cd prysm
 curl https://raw.githubusercontent.com/prysmaticlabs/prysm/master/prysm.bat --output prysm.bat
 reg add HKCU\Console /v VirtualTerminalLevel /t REG_DWORD /d 1
 ```
@@ -28,7 +27,6 @@ reg add HKCU\Console /v VirtualTerminalLevel /t REG_DWORD /d 1
     <p>Navigate to your <code>consensus</code> directory and run the following commands:</p>
 
 ```
-mkdir prysm && cd prysm
 curl https://raw.githubusercontent.com/prysmaticlabs/prysm/master/prysm.sh --output prysm.sh && chmod +x prysm.sh
 ```
 
@@ -48,8 +46,6 @@ curl https://raw.githubusercontent.com/prysmaticlabs/prysm/master/prysm.sh --out
 import JwtGenerationPartial from '@site/docs/partials/_jwt-generation-partial.md';
 
 <JwtGenerationPartial />
-
-This guide assumes that you've placed your `jwt.hex` file in your `consensus` directory, but you can place it anywhere and revise the below commands as needed.
     
   </TabItem>
 </Tabs>

--- a/website/docs/install/partials/_quickstart-intro.md
+++ b/website/docs/install/partials/_quickstart-intro.md
@@ -11,7 +11,7 @@ import MultidimensionalContentControlsPartial from '@site/docs/partials/_multidi
 
 ## Introduction
 
-Prysm is an implementation of the [Ethereum proof-of-stake consensus specification](https://github.com/ethereum/consensus-specs). In this quickstart, you’ll use Prysm to run an Ethereum node and optionally a validator. This will let you stake 32 ETH using hardware that you manage.
+Prysm is an implementation of the [Ethereum proof-of-stake consensus specification](https://github.com/ethereum/consensus-specs). In this quickstart, you’ll use Prysm to run an Ethereum node and optionally a validator client. This will let you stake 32 ETH using hardware that you manage.
 
 This is a beginner-friendly guide. Familiarity with the command line is expected, but otherwise this guide makes no assumptions about your technical skills or prior knowledge.
 
@@ -19,7 +19,7 @@ At a high level, we'll walk through the following flow:
 
  1. Configure an **execution node** using an execution-layer client.
  2. Configure a **beacon node** using Prysm, a consensus-layer client.
- 3. Configure a **validator** and stake ETH using Prysm (optional).
+ 3. Configure a **validator client** and stake ETH using Prysm (optional).
 
 <br />
 

--- a/website/docs/install/partials/_quickstart-prereqs.md
+++ b/website/docs/install/partials/_quickstart-prereqs.md
@@ -1,22 +1,21 @@
 <table>
     <tbody>
       <tr>
-          <th style={{minWidth: 180 + 'px'}}>Node type</th> 
+          <th style={{minWidth: 180 + 'px'}}>Type</th> 
           <th>Benefits</th>
           <th>Requirements</th>
       </tr>
       <tr>
-        <td><strong>Execution + beacon</strong></td>
+        <td><strong>Execution + Beacon</strong></td>
         <td>
         <ul> 
           <li>Contributes to the security of Ethereum's ecosystem.</li>    
           <li>Lets you access the Ethereum network directly without having to trust a third party service.</li> 
-          <li>Lets you run a validator post-Merge.</li> 
         </ul> 
         </td>
         <td>
           <ul> 
-            <li><strong>Software</strong>: Execution client, beacon node client (instructions for clients below), <a href='https://curl.se/download.html'>curl</a></li>
+            <li><strong>Software</strong>: Execution node client, beacon node client (instructions for clients below), <a href='https://curl.se/download.html'>curl</a></li>
             <li><strong>OS</strong>: 64-bit Linux, Mac OS X 10.14+, Windows 10+ 64-bit</li>   
             <li><strong>CPU</strong>: 4+ cores @ 2.8+ GHz</li> 
             <li><strong>Memory</strong>: 16GB+ RAM</li> 
@@ -28,7 +27,9 @@
       <tr>
           <td><strong>Validator</strong></td>
           <td>
-          Lets you stake ETH, propose + validate blocks, earn staking rewards + transaction fee tips.
+          <ul>
+            <li>Lets you stake ETH, propose + validate blocks, earn staking rewards + transaction fee tips.</li>
+          </ul>
           </td>
           <td>
             <ul> 
@@ -49,9 +50,9 @@
 
 - **If you're staking ETH as a validator, try this guide on a testnet first**, *then* mainnet.
 - **Keep things simple**. This guidance assumes all client software will run on a single machine.
-- **Review the latest advisories** for the network(s) that you're using: [Goerli-Prater](https://goerli.launchpad.ethereum.org/en/), [Mainnet](https://launchpad.ethereum.org/en/).
+- **Review the latest advisories** for the network(s) that you're using: [Goerli](https://goerli.launchpad.ethereum.org/en/), [Holesky](https://holesky.launchpad.ethereum.org/en/) or [Mainnet](https://launchpad.ethereum.org/en/).
 - Review all of our [published security best practices](/docs/security-best-practices).
-- **Join the community** - join our [mailing list](https://groups.google.com/g/prysm-dev), the [Prysm Discord server](https://discord.gg/prysmaticlabs), [r/ethstaker](https://www.reddit.com/r/ethstaker/), and the [EthStaker Discord server](https://discord.io/ethstaker) for updates and support.
+- **Join the community** - join our [mailing list](https://groups.google.com/g/prysm-dev), the [Prysm Discord server](https://discord.gg/prysmaticlabs), [r/ethstaker](https://www.reddit.com/r/ethstaker/), and the [EthStaker Discord server](https://discord.gg/ethstaker) for updates and support.
 
 </div>
 

--- a/website/docs/install/partials/_quickstart-run-beacon-node.md
+++ b/website/docs/install/partials/_quickstart-run-beacon-node.md
@@ -2,7 +2,8 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 <p className='hidden-in-jwt-guide hidden-in-mergeprep-guide'>In this step, you'll run a beacon node using Prysm.</p>
-
+<p>There is two main ways to sync a beacon node: from genesis, and from a checkpoint. It is safer and a considerably faster to sync from a checkpoint. When syncing from a checkpoint, the simplest is to connect to a checkpoint sync endpoint. A non exhaustive <a href='https://eth-clients.github.io/checkpoint-sync-endpoints'> list of checkpoint sync endpoints</a> is available.</p>
+<p>In the following examples, we'll use the checkpoint sync endpoint provided by <a href='https://beaconstate.info/'>beaconstate.info</a>. <strong>Feel free to use the one you want.</strong></p>
 <Tabs groupId="os" defaultValue="others" values={[
     {label: 'Windows', value: 'win'},
     {label: 'Linux, MacOS, Arm64', value: 'others'}
@@ -21,11 +22,11 @@ import TabItem from '@theme/TabItem';
         ]}>
           <TabItem value="jwt">
             <p>Navigate to your <code>consensus</code> directory and run the following command to start your beacon node that connects to your local execution node by replacing <code>&lt;PATH_TO_JWT_FILE&gt;</code> by the path to the JWT file generated during the previous step:</p>
-            <pre><code>prysm.bat beacon-chain --execution-endpoint=http://localhost:8551 --mainnet --jwt-secret=&lt;PATH_TO_JWT_FILE&gt;</code></pre>
+            <pre><code>prysm.bat beacon-chain --execution-endpoint=http://localhost:8551 --mainnet --jwt-secret=&lt;PATH_TO_JWT_FILE&gt; --checkpoint-sync-url=https://beaconstate.info --genesis-beacon-api-url=https://beaconstate.info</code></pre>
           </TabItem>
           <TabItem value="ipc">
             <p>Navigate to your <code>consensus</code> directory and run the following command to start your beacon node that connects to your local execution node by replacing <code>&lt;PATH_TO_IPC_FILE&gt;</code> by the path to the IPC file the execution client created for you during the previous step:</p>
-            <pre><code>prysm.bat beacon-chain --execution-endpoint=&lt;PATH_TO_IPC_FILE&gt; --mainnet </code></pre>
+            <pre><code>prysm.bat beacon-chain --execution-endpoint=&lt;PATH_TO_IPC_FILE&gt; --mainnet --checkpoint-sync-url=https://beaconstate.info --genesis-beacon-api-url=https://beaconstate.info</code></pre>
           </TabItem>
         </Tabs>
       </TabItem>
@@ -35,8 +36,8 @@ import TabItem from '@theme/TabItem';
           {label: 'JWT', value: 'jwt'},
           {label: 'IPC', value: 'ipc'}
         ]}>
-          <TabItem value="jwt"><pre><code>prysm.bat beacon-chain --execution-endpoint=http://localhost:8551 --goerli --jwt-secret=&lt;PATH_TO_JWT_FILE&gt; --genesis-state=genesis.ssz </code></pre></TabItem>
-          <TabItem value="ipc"><pre><code>prysm.bat beacon-chain --execution-endpoint=&lt;PATH_TO_IPC_FILE&gt; --goerli --genesis-state=genesis.ssz</code></pre></TabItem>
+          <TabItem value="jwt"><pre><code>prysm.bat beacon-chain --execution-endpoint=http://localhost:8551 --goerli --jwt-secret=&lt;PATH_TO_JWT_FILE&gt; --genesis-state=genesis.ssz --checkpoint-sync-url=https://goerli.beaconstate.info --genesis-beacon-api-url=https://goerli.beaconstate.info</code></pre></TabItem>
+          <TabItem value="ipc"><pre><code>prysm.bat beacon-chain --execution-endpoint=&lt;PATH_TO_IPC_FILE&gt; --goerli --genesis-state=genesis.ssz --checkpoint-sync-url=https://goerli.beaconstate.ethstaker.cc --genesis-beacon-api-url=https://goerli.beaconstate.ethstaker.cc</code></pre></TabItem>
         </Tabs>
         <p>You may wonder why the previous link contains the "Prater" word instead of "Goerli". The reason is, in the pre-merge world, "Goerli" was the name of the execution layer for this testnet, and "Prater" the name of the consensus layer for this testnet. Post-merge, the name "Prater" was deprecated and now only "Goerli" remains.</p>
       </TabItem>
@@ -46,8 +47,8 @@ import TabItem from '@theme/TabItem';
           {label: 'JWT', value: 'jwt'},
           {label: 'IPC', value: 'ipc'}
         ]}>
-          <TabItem value="jwt"><pre><code>prysm.bat beacon-chain --execution-endpoint=http://localhost:8551 --sepolia --jwt-secret=&lt;PATH_TO_JWT_FILE&gt; --genesis-state=genesis.ssz</code></pre></TabItem>
-          <TabItem value="ipc"><pre><code>prysm.bath beacon-chain --execution-endpoint=&lt;PATH_TO_IPC_FILE&gt; --sepolia --genesis-state=genesis.ssz</code></pre></TabItem>
+          <TabItem value="jwt"><pre><code>prysm.bat beacon-chain --execution-endpoint=http://localhost:8551 --sepolia --jwt-secret=&lt;PATH_TO_JWT_FILE&gt; --genesis-state=genesis.ssz --checkpoint-sync-url=https://sepolia.beaconstate.info --genesis-beacon-api-url=https://sepolia.beaconstate.info</code></pre></TabItem>
+          <TabItem value="ipc"><pre><code>prysm.bat beacon-chain --execution-endpoint=&lt;PATH_TO_IPC_FILE&gt; --sepolia --genesis-state=genesis.ssz --checkpoint-sync-url=https://sepolia.beaconstate.info --genesis-beacon-api-url=https://sepolia.beaconstate.info</code></pre></TabItem>
         </Tabs>
       </TabItem>
       <TabItem value="holesky">
@@ -56,8 +57,8 @@ import TabItem from '@theme/TabItem';
           {label: 'JWT', value: 'jwt'},
           {label: 'IPC', value: 'ipc'}
         ]}>
-          <TabItem value="jwt"><pre><code>prysm.bat beacon-chain --execution-endpoint=http://localhost:8551 --holesky --jwt-secret=&lt;PATH_TO_JWT_FILE&gt; --genesis-state=genesis.ssz</code></pre></TabItem>
-          <TabItem value="ipc"><pre><code>prysm.bat beacon-chain --execution-endpoint=&lt;PATH_TO_IPC_FILE&gt; --holesky --genesis-state=genesis.ssz</code></pre></TabItem>
+          <TabItem value="jwt"><pre><code>prysm.bat beacon-chain --execution-endpoint=http://localhost:8551 --holesky --jwt-secret=&lt;PATH_TO_JWT_FILE&gt; --genesis-state=genesis.ssz --checkpoint-sync-url=https://holesky.beaconstate.info --genesis-beacon-api-url=https://holesky.beaconstate.info</code></pre></TabItem>
+          <TabItem value="ipc"><pre><code>prysm.bat beacon-chain --execution-endpoint=&lt;PATH_TO_IPC_FILE&gt; --holesky --genesis-state=genesis.ssz --checkpoint-sync-url=https://holesky.beaconstate.info --genesis-beacon-api-url=https://holesky.beaconstate.info</code></pre></TabItem>
         </Tabs>
       </TabItem>
     </Tabs>
@@ -76,11 +77,11 @@ import TabItem from '@theme/TabItem';
         ]}>
           <TabItem value="jwt">
             <p>Navigate to your <code>consensus</code> directory and run the following command to start your beacon node that connects to your local execution node by replacing <code>&lt;PATH_TO_JWT_FILE&gt;</code> by the path to the JWT file generated during the previous step:</p>
-            <pre><code>./prysm.sh beacon-chain --execution-endpoint=http://localhost:8551 --mainnet --jwt-secret=&lt;PATH_TO_JWT_FILE&gt;</code></pre>
+            <pre><code>./prysm.sh beacon-chain --execution-endpoint=http://localhost:8551 --mainnet --jwt-secret=&lt;PATH_TO_JWT_FILE&gt; --checkpoint-sync-url=https://beaconstate.info --genesis-beacon-api-url=https://beaconstate.info</code></pre>
           </TabItem>
           <TabItem value="ipc">
             <p>Navigate to your <code>consensus</code> directory and run the following command to start your beacon node that connects to your local execution node by replacing <code>&lt;PATH_TO_IPC_FILE&gt;</code> by the path to the IPC file the execution client created for you during the previous step:</p>
-            <pre><code>./prysm.sh beacon-chain --execution-endpoint=&lt;PATH_TO_IPC_FILE&gt; --mainnet </code></pre>
+            <pre><code>./prysm.sh beacon-chain --execution-endpoint=&lt;PATH_TO_IPC_FILE&gt; --mainnet --checkpoint-sync-url=https://beaconstate.info --genesis-beacon-api-url=https://beaconstate.info</code></pre>
           </TabItem>
         </Tabs>
       </TabItem>
@@ -90,8 +91,8 @@ import TabItem from '@theme/TabItem';
           {label: 'JWT', value: 'jwt'},
           {label: 'IPC', value: 'ipc'}
           ]}>
-            <TabItem value="jwt"><pre><code>./prysm.sh beacon-chain --execution-endpoint=http://localhost:8551 --goerli --jwt-secret=&lt;PATH_TO_JWT_FILE&gt; --genesis-state=genesis.ssz </code></pre></TabItem>
-            <TabItem value="ipc"><pre><code>./prysm.sh beacon-chain --execution-endpoint=&lt;PATH_TO_IPC_FILE&gt; --goerli --genesis-state=genesis.ssz</code></pre></TabItem>
+            <TabItem value="jwt"><pre><code>./prysm.sh beacon-chain --execution-endpoint=http://localhost:8551 --goerli --jwt-secret=&lt;PATH_TO_JWT_FILE&gt; --genesis-state=genesis.ssz --checkpoint-sync-url=https://goerli.beaconstate.info --genesis-beacon-api-url=https://goerli.beaconstate.info</code></pre></TabItem>
+            <TabItem value="ipc"><pre><code>./prysm.sh beacon-chain --execution-endpoint=&lt;PATH_TO_IPC_FILE&gt; --goerli --genesis-state=genesis.ssz --checkpoint-sync-url=https://goerli.beaconstate.info --genesis-beacon-api-url=https://goerli.beaconstate.info</code></pre></TabItem>
           </Tabs>
           <p>You may wonder why the previous link contains the "Prater" word instead of "Goerli". The reason is, in the pre-merge world, "Goerli" was the name of the execution layer for this testnet, and "Prater" the name of the consensus layer for this testnet. Post-merge, the name "Prater" was deprecated and now only "Goerli" remains.</p>
       </TabItem>
@@ -101,8 +102,8 @@ import TabItem from '@theme/TabItem';
           {label: 'JWT', value: 'jwt'},
           {label: 'IPC', value: 'ipc'}
         ]}>
-          <TabItem value="jwt"><pre><code>./prysm.sh beacon-chain --execution-endpoint=http://localhost:8551 --sepolia --jwt-secret=&lt;PATH_TO_JWT_FILE&gt; --genesis-state=genesis.ssz</code></pre></TabItem>
-          <TabItem value="ipc"><pre><code>./prysm.sh beacon-chain --execution-endpoint=&lt;PATH_TO_IPC_FILE&gt; --sepolia --genesis-state=genesis.ssz</code></pre></TabItem>
+          <TabItem value="jwt"><pre><code>./prysm.sh beacon-chain --execution-endpoint=http://localhost:8551 --sepolia --jwt-secret=&lt;PATH_TO_JWT_FILE&gt; --genesis-state=genesis.ssz --checkpoint-sync-url=https://sepolia.beaconstate.info --genesis-beacon-api-url=https://sepolia.beaconstate.info</code></pre></TabItem>
+          <TabItem value="ipc"><pre><code>./prysm.sh beacon-chain --execution-endpoint=&lt;PATH_TO_IPC_FILE&gt; --sepolia --genesis-state=genesis.ssz --checkpoint-sync-url=https://sepolia.beaconstate.info --genesis-beacon-api-url=https://sepolia.beaconstate.info</code></pre></TabItem>
           </Tabs>
       </TabItem>
       <TabItem value="holesky">
@@ -111,8 +112,8 @@ import TabItem from '@theme/TabItem';
           {label: 'JWT', value: 'jwt'},
           {label: 'IPC', value: 'ipc'}
         ]}>
-          <TabItem value="jwt"><pre><code>./prysm.sh beacon-chain --execution-endpoint=http://localhost:8551 --holesky --jwt-secret=&lt;PATH_TO_JWT_FILE&gt; --genesis-state=genesis.ssz</code></pre></TabItem>
-          <TabItem value="ipc"><pre><code>./prysm.sh beacon-chain --execution-endpoint=&lt;PATH_TO_IPC_FILE&gt; --holesky --genesis-state=genesis.ssz</code></pre></TabItem>
+          <TabItem value="jwt"><pre><code>./prysm.sh beacon-chain --execution-endpoint=http://localhost:8551 --holesky --jwt-secret=&lt;PATH_TO_JWT_FILE&gt; --genesis-state=genesis.ssz --checkpoint-sync-url=https://holesky.beaconstate.info --genesis-beacon-api-url=https://holesky.beaconstate.info</code></pre></TabItem>
+          <TabItem value="ipc"><pre><code>./prysm.sh beacon-chain --execution-endpoint=&lt;PATH_TO_IPC_FILE&gt; --holesky --genesis-state=genesis.ssz --checkpoint-sync-url=https://holesky.beaconstate.info --genesis-beacon-api-url=https://holesky.beaconstate.info</code></pre></TabItem>
         </Tabs>
       </TabItem>
     </Tabs>
@@ -121,11 +122,12 @@ import TabItem from '@theme/TabItem';
 
 <div className='hidden-in-jwt-guide hidden-in-mergeprep-guide'>
 
-If you are plannig to run a validator, it is <strong>strongly</strong> advised to use the <code>--suggested-fee-recipient=<WALLET ADDRESS\></code> option. When your validator proposes a block, it will allow you to earn block priority fees, also sometimes called "tips". See [How to configure Fee Recipient](../../execution-node/fee-recipient.md) for more information about this feature.
+Syncing from a checkpoint usually takes a couple of minutes. See [Sync from a checkpoint](../../prysm-usage/checkpoint-sync.md) for more information about this feature.
 
-Your beacon node will now begin syncing from genesis. This usually takes a couple days, but it can take longer depending on your network and hardware specs.
+If you wish to sync from genesis, you need to remove <code>--checkpoint-sync-url</code> and <code>--genesis-beacon-api-url</code> flags from the previous command. Syncing from genesis usually takes a couple days, but it can take longer depending on your network and hardware specs.
 
-It is also possible to sync your beacon node from a checkpoint. This option is considered safer, and will allow your beacon node to sync considerably faster. See [Sync from a checkpoint](../../prysm-usage/checkpoint-sync.md) for more information about this feature.
+If you are planning to run a validator, it is <strong>strongly</strong> advised to use the <code>--suggested-fee-recipient=<WALLET ADDRESS\></code> option. When your validator proposes a block, it will allow you to earn block priority fees, also sometimes called "tips".
+
 
 <p className="hidden-in-mergeprep-guide">Congratulations - you’re now running a <strong>full Ethereum node</strong>. To check the status of your node, visit <a href='https://docs.prylabs.network/docs/monitoring/checking-status'>Check node and validator status</a>.</p>
 

--- a/website/docs/install/partials/_quickstart-run-beacon-node.md
+++ b/website/docs/install/partials/_quickstart-run-beacon-node.md
@@ -9,107 +9,111 @@ import TabItem from '@theme/TabItem';
 ]}>
   <TabItem value="win">
     <Tabs groupId="network" defaultValue="mainnet" values={[
-        {label: 'Mainnet', value: 'mainnet'},
-        {label: 'Goerli-Prater', value: 'goerli-prater'},
-        {label: 'Sepolia', value: 'sepolia'},
-        {label: 'Holesky', value: 'holesky'}
+      {label: 'Mainnet', value: 'mainnet'},
+      {label: 'Goerli', value: 'goerli'},
+      {label: 'Sepolia', value: 'sepolia'},
+      {label: 'Holesky', value: 'holesky'}
     ]}>
-      <TabItem value="mainnet">  
-        <p className='hidden-in-jwt-guide hidden-in-mergeprep-guide'>Use the following command to start a beacon node that connects to your local execution node:</p>
+      <TabItem value="mainnet">
         <Tabs groupId="protocol" defaultValue="jwt" values={[
-            {label: 'JWT', value: 'jwt'},
-            {label: 'IPC', value: 'ipc'}
-            ]}>
-                <TabItem value="jwt"><pre><code>prysm.bat beacon-chain --execution-endpoint=http://localhost:8551 --jwt-secret=path/to/jwt.hex --suggested-fee-recipient=0x01234567722E6b0000012BFEBf6177F1D2e9758D9</code></pre></TabItem>
-                <TabItem value="ipc">
-                  <div className="admonition admonition-info alert alert--info"><div className="admonition-content"><p><code>--http-web3provider</code> is deprecated and has been replaced with <code>--execution-endpoint</code>, but IPC currently only works through <code>--http-web3provider</code> on Windows. This will be fixed in our next release. You can safely ignore any related "deprecated flag" warnings you see in the meantime.</p></div></div>
-                  <pre><code>prysm.bat beacon-chain --http-web3provider=//./pipe/&lt;your.ipc&gt; --suggested-fee-recipient=0x01234567722E6b0000012BFEBf6177F1D2e9758D9</code></pre>
-                </TabItem>
-            </Tabs>
+          {label: 'JWT', value: 'jwt'},
+          {label: 'IPC', value: 'ipc'}
+        ]}>
+          <TabItem value="jwt">
+            <p>Navigate to your <code>consensus</code> directory and run the following command to start your beacon node that connects to your local execution node by replacing <code>&lt;PATH_TO_JWT_FILE&gt;</code> by the path to the JWT file generated during the previous step:</p>
+            <pre><code>prysm.bat beacon-chain --execution-endpoint=http://localhost:8551 --mainnet --jwt-secret=&lt;PATH_TO_JWT_FILE&gt;</code></pre>
+          </TabItem>
+          <TabItem value="ipc">
+            <p>Navigate to your <code>consensus</code> directory and run the following command to start your beacon node that connects to your local execution node by replacing <code>&lt;PATH_TO_IPC_FILE&gt;</code> by the path to the IPC file the execution client created for you during the previous step:</p>
+            <pre><code>prysm.bat beacon-chain --execution-endpoint=&lt;PATH_TO_IPC_FILE&gt; --mainnet </code></pre>
+          </TabItem>
+        </Tabs>
       </TabItem>
-      <TabItem value="goerli-prater">
-        <p className='hidden-in-jwt-guide'>Download the <a href='https://github.com/eth-clients/eth2-networks/raw/master/shared/prater/genesis.ssz'>Prater genesis state from Github</a> into your <code>consensus/prysm</code> directory. Then use the following command to start a beacon node that connects to your local execution node:</p>
+      <TabItem value="goerli">
+        <p className='hidden-in-jwt-guide'>Download the <a href='https://github.com/eth-clients/eth2-networks/raw/master/shared/prater/genesis.ssz'>Goerli genesis state from Github</a> into your <code>consensus</code> directory. Then use the following command to start a beacon node that connects to your local execution node by replacing <code>&lt;PATH_TO_IPC_FILE&gt;</code> by the path to the IPC file the execution client created for you during the previous step:</p>
         <Tabs groupId="protocol" defaultValue="jwt" values={[
-            {label: 'JWT', value: 'jwt'},
-            {label: 'IPC', value: 'ipc'}
-            ]}>
-                <TabItem value="jwt"><pre><code>prysm.bat beacon-chain --execution-endpoint=http://localhost:8551 --prater --jwt-secret=path/to/jwt.hex --genesis-state=genesis.ssz --suggested-fee-recipient=0x01234567722E6b0000012BFEBf6177F1D2e9758D9</code></pre></TabItem>
-                <TabItem value="ipc">
-                <div className="admonition admonition-info alert alert--info"><div className="admonition-content"><p><code>--http-web3provider</code> is deprecated and has been replaced with <code>--execution-endpoint</code>, but IPC currently only works through <code>--http-web3provider</code> on Windows. This will be fixed in our next release. You can safely ignore any related "deprecated flag" warnings you see in the meantime.</p></div></div>
-                <pre><code>prysm.bat beacon-chain --http-web3provider=//./pipe/&lt;your.ipc&gt; --prater --genesis-state=genesis.ssz --suggested-fee-recipient=0x01234567722E6b0000012BFEBf6177F1D2e9758D9</code></pre></TabItem>
-            </Tabs> 
+          {label: 'JWT', value: 'jwt'},
+          {label: 'IPC', value: 'ipc'}
+        ]}>
+          <TabItem value="jwt"><pre><code>prysm.bat beacon-chain --execution-endpoint=http://localhost:8551 --goerli --jwt-secret=&lt;PATH_TO_JWT_FILE&gt; --genesis-state=genesis.ssz </code></pre></TabItem>
+          <TabItem value="ipc"><pre><code>prysm.bat beacon-chain --execution-endpoint=&lt;PATH_TO_IPC_FILE&gt; --goerli --genesis-state=genesis.ssz</code></pre></TabItem>
+        </Tabs>
+        <p>You may wonder why the previous link contains the "Prater" word instead of "Goerli". The reason is, in the pre-merge world, "Goerli" was the name of the execution layer for this testnet, and "Prater" the name of the consensus layer for this testnet. Post-merge, the name "Prater" was deprecated and now only "Goerli" remains.</p>
       </TabItem>
       <TabItem value="sepolia">
-        <p className='hidden-in-jwt-guide'>Download the <a href='https://github.com/eth-clients/merge-testnets/blob/main/sepolia/genesis.ssz'>Sepolia genesis state from Github</a> into your <code>consensus/prysm</code> directory. Then use the following command to start a beacon node that connects to your local execution node:</p>
+        <p className='hidden-in-jwt-guide'>Download the <a href='https://github.com/eth-clients/merge-testnets/blob/main/sepolia/genesis.ssz'>Sepolia genesis state from Github</a> into your <code>consensus</code> directory. Then use the following command to start a beacon node that connects to your local execution node by replacing <code>&lt;PATH_TO_IPC_FILE&gt;</code> by the path to the IPC file the execution client created for you during the previous step:</p>
         <Tabs groupId="protocol" defaultValue="jwt" values={[
-            {label: 'JWT', value: 'jwt'},
-            {label: 'IPC', value: 'ipc'}
-            ]}>
-                <TabItem value="jwt"><pre><code>prysm.bat beacon-chain --execution-endpoint=http://localhost:8551 --sepolia --suggested-fee-recipient=0x01234567722E6b0000012BFEBf6177F1D2e9758D9 --jwt-secret=jwt.hex --genesis-state=genesis.ssz</code></pre></TabItem>
-                <TabItem value="ipc">
-                <div className="admonition admonition-info alert alert--info"><div className="admonition-content"><p><code>--http-web3provider</code> is deprecated and has been replaced with <code>--execution-endpoint</code>, but IPC currently only works through <code>--http-web3provider</code> on Windows. This will be fixed in our next release. You can safely ignore any related "deprecated flag" warnings you see in the meantime.</p></div></div>
-                <pre><code>prysm.bat beacon-chain --http-web3provider=//./pipe/&lt;your.ipc&gt; --sepolia --suggested-fee-recipient=0x01234567722E6b0000012BFEBf6177F1D2e9758D9 --genesis-state=genesis.ssz</code></pre></TabItem>
-            </Tabs>
+          {label: 'JWT', value: 'jwt'},
+          {label: 'IPC', value: 'ipc'}
+        ]}>
+          <TabItem value="jwt"><pre><code>prysm.bat beacon-chain --execution-endpoint=http://localhost:8551 --sepolia --jwt-secret=&lt;PATH_TO_JWT_FILE&gt; --genesis-state=genesis.ssz</code></pre></TabItem>
+          <TabItem value="ipc"><pre><code>prysm.bath beacon-chain --execution-endpoint=&lt;PATH_TO_IPC_FILE&gt; --sepolia --genesis-state=genesis.ssz</code></pre></TabItem>
+        </Tabs>
       </TabItem>
       <TabItem value="holesky">
-        <p className='hidden-in-jwt-guide'>Download the <a href='https://github.com/eth-clients/holesky/blob/main/custom_config_data/genesis.ssz'>Holesky genesis state from Github</a> into your <code>consensus/prysm</code> directory. Then use the following command to start a beacon node that connects to your local execution node:</p>
+        <p className='hidden-in-jwt-guide'>Download the <a href='https://github.com/eth-clients/holesky/blob/main/custom_config_data/genesis.ssz'>Holesky genesis state from Github</a> into your <code>consensus</code> directory. Then use the following command to start a beacon node that connects to your local execution node by replacing <code>&lt;PATH_TO_IPC_FILE&gt;</code> by the path to the IPC file the execution client created for you during the previous step:</p>
         <Tabs groupId="protocol" defaultValue="jwt" values={[
-            {label: 'JWT', value: 'jwt'},
-            {label: 'IPC', value: 'ipc'}
-            ]}>
-                <TabItem value="jwt"><pre><code>prysm.bat beacon-chain --execution-endpoint=http://localhost:8551 --holesky --suggested-fee-recipient=0x01234567722E6b0000012BFEBf6177F1D2e9758D9 --jwt-secret=jwt.hex --genesis-state=genesis.ssz</code></pre></TabItem>
-                <TabItem value="ipc">
-                <pre><code>prysm.bat beacon-chain --execution-endpoint=//./pipe/&lt;your.ipc&gt; --holesky --suggested-fee-recipient=0x01234567722E6b0000012BFEBf6177F1D2e9758D9 --genesis-state=genesis.ssz</code></pre></TabItem>
-            </Tabs>
+          {label: 'JWT', value: 'jwt'},
+          {label: 'IPC', value: 'ipc'}
+        ]}>
+          <TabItem value="jwt"><pre><code>prysm.bat beacon-chain --execution-endpoint=http://localhost:8551 --holesky --jwt-secret=&lt;PATH_TO_JWT_FILE&gt; --genesis-state=genesis.ssz</code></pre></TabItem>
+          <TabItem value="ipc"><pre><code>prysm.bat beacon-chain --execution-endpoint=&lt;PATH_TO_IPC_FILE&gt; --holesky --genesis-state=genesis.ssz</code></pre></TabItem>
+        </Tabs>
       </TabItem>
     </Tabs>
   </TabItem>
   <TabItem value="others">
     <Tabs groupId="network" defaultValue="mainnet" values={[
-        {label: 'Mainnet', value: 'mainnet'},
-        {label: 'Goerli-Prater', value: 'goerli-prater'},
-        {label: 'Sepolia', value: 'sepolia'},
-        {label: 'Holesky', value: 'holesky'}
+      {label: 'Mainnet', value: 'mainnet'},
+      {label: 'Goerli', value: 'goerli'},
+      {label: 'Sepolia', value: 'sepolia'},
+      {label: 'Holesky', value: 'holesky'}
     ]}>
       <TabItem value="mainnet">
-        <p>Use the following command to start a beacon node that connects to your local execution node:</p>
         <Tabs groupId="protocol" defaultValue="jwt" values={[
-            {label: 'JWT', value: 'jwt'},
-            {label: 'IPC', value: 'ipc'}
-            ]}>
-                <TabItem value="jwt"><pre><code>./prysm.sh beacon-chain --execution-endpoint=http://localhost:8551 --jwt-secret=path/to/jwt.hex --suggested-fee-recipient=0x01234567722E6b0000012BFEBf6177F1D2e9758D9</code></pre></TabItem>
-                <TabItem value="ipc"><pre><code>./prysm.sh beacon-chain --execution-endpoint=$HOME/.ethereum/&lt;your.ipc&gt; --suggested-fee-recipient=0x01234567722E6b0000012BFEBf6177F1D2e9758D9</code></pre></TabItem>
-            </Tabs>
+          {label: 'JWT', value: 'jwt'},
+          {label: 'IPC', value: 'ipc'}
+        ]}>
+          <TabItem value="jwt">
+            <p>Navigate to your <code>consensus</code> directory and run the following command to start your beacon node that connects to your local execution node by replacing <code>&lt;PATH_TO_JWT_FILE&gt;</code> by the path to the JWT file generated during the previous step:</p>
+            <pre><code>./prysm.sh beacon-chain --execution-endpoint=http://localhost:8551 --mainnet --jwt-secret=&lt;PATH_TO_JWT_FILE&gt;</code></pre>
+          </TabItem>
+          <TabItem value="ipc">
+            <p>Navigate to your <code>consensus</code> directory and run the following command to start your beacon node that connects to your local execution node by replacing <code>&lt;PATH_TO_IPC_FILE&gt;</code> by the path to the IPC file the execution client created for you during the previous step:</p>
+            <pre><code>./prysm.sh beacon-chain --execution-endpoint=&lt;PATH_TO_IPC_FILE&gt; --mainnet </code></pre>
+          </TabItem>
+        </Tabs>
       </TabItem>
-      <TabItem value="goerli-prater">
-        <p className='hidden-in-jwt-guide'>Download the <a href='https://github.com/eth-clients/eth2-networks/raw/master/shared/prater/genesis.ssz'>Prater genesis state from Github</a> into your <code>consensus/prysm</code> directory. Then use the following command to start a beacon node that connects to your local execution node:</p>
+      <TabItem value="goerli">
+        <p className='hidden-in-jwt-guide'>Download the <a href='https://github.com/eth-clients/eth2-networks/raw/master/shared/prater/genesis.ssz'>Goerli genesis state from Github</a> into your <code>consensus</code> directory. Then use the following command to start a beacon node that connects to your local execution node by replacing <code>&lt;PATH_TO_IPC_FILE&gt;</code> by the path to the IPC file the execution client created for you during the previous step:</p>
         <Tabs groupId="protocol" defaultValue="jwt" values={[
-            {label: 'JWT', value: 'jwt'},
-            {label: 'IPC', value: 'ipc'}
-            ]}>
-                <TabItem value="jwt"><pre><code>./prysm.sh beacon-chain --execution-endpoint=http://localhost:8551 --prater --jwt-secret=path/to/jwt.hex --genesis-state=genesis.ssz --suggested-fee-recipient=0x01234567722E6b0000012BFEBf6177F1D2e9758D9</code></pre></TabItem>
-                <TabItem value="ipc"><pre><code>./prysm.sh beacon-chain --execution-endpoint=$HOME/.ethereum/&lt;your.ipc&gt; --prater --genesis-state=genesis.ssz --suggested-fee-recipient=0x01234567722E6b0000012BFEBf6177F1D2e9758D9</code></pre></TabItem>
-            </Tabs>
+          {label: 'JWT', value: 'jwt'},
+          {label: 'IPC', value: 'ipc'}
+          ]}>
+            <TabItem value="jwt"><pre><code>./prysm.sh beacon-chain --execution-endpoint=http://localhost:8551 --goerli --jwt-secret=&lt;PATH_TO_JWT_FILE&gt; --genesis-state=genesis.ssz </code></pre></TabItem>
+            <TabItem value="ipc"><pre><code>./prysm.sh beacon-chain --execution-endpoint=&lt;PATH_TO_IPC_FILE&gt; --goerli --genesis-state=genesis.ssz</code></pre></TabItem>
+          </Tabs>
+          <p>You may wonder why the previous link contains the "Prater" word instead of "Goerli". The reason is, in the pre-merge world, "Goerli" was the name of the execution layer for this testnet, and "Prater" the name of the consensus layer for this testnet. Post-merge, the name "Prater" was deprecated and now only "Goerli" remains.</p>
       </TabItem>
       <TabItem value="sepolia">
-        <p className='hidden-in-jwt-guide'>Download the <a href='https://github.com/eth-clients/merge-testnets/blob/main/sepolia/genesis.ssz'>Sepolia genesis state from Github</a> into your <code>consensus/prysm</code> directory. Then use the following command to start a beacon node that connects to your local execution node:</p>
+        <p className='hidden-in-jwt-guide'>Download the <a href='https://github.com/eth-clients/merge-testnets/blob/main/sepolia/genesis.ssz'>Sepolia genesis state from Github</a> into your <code>consensus</code> directory. Then use the following command to start a beacon node that connects to your local execution node by replacing <code>&lt;PATH_TO_IPC_FILE&gt;</code> by the path to the IPC file the execution client created for you during the previous step:</p>
         <Tabs groupId="protocol" defaultValue="jwt" values={[
-            {label: 'JWT', value: 'jwt'},
-            {label: 'IPC', value: 'ipc'}
-            ]}>
-                <TabItem value="jwt"><pre><code>./prysm.sh beacon-chain --execution-endpoint=http://localhost:8551 --sepolia --suggested-fee-recipient=0x01234567722E6b0000012BFEBf6177F1D2e9758D9 --jwt-secret=jwt.hex --genesis-state=genesis.ssz</code></pre></TabItem>
-                <TabItem value="ipc"><pre><code>./prysm.sh beacon-chain --execution-endpoint=$HOME/.ethereum/&lt;your.ipc&gt; --sepolia --suggested-fee-recipient=0x01234567722E6b0000012BFEBf6177F1D2e9758D9 --genesis-state=genesis.ssz</code></pre></TabItem>
-            </Tabs>
+          {label: 'JWT', value: 'jwt'},
+          {label: 'IPC', value: 'ipc'}
+        ]}>
+          <TabItem value="jwt"><pre><code>./prysm.sh beacon-chain --execution-endpoint=http://localhost:8551 --sepolia --jwt-secret=&lt;PATH_TO_JWT_FILE&gt; --genesis-state=genesis.ssz</code></pre></TabItem>
+          <TabItem value="ipc"><pre><code>./prysm.sh beacon-chain --execution-endpoint=&lt;PATH_TO_IPC_FILE&gt; --sepolia --genesis-state=genesis.ssz</code></pre></TabItem>
+          </Tabs>
       </TabItem>
       <TabItem value="holesky">
-        <p className='hidden-in-jwt-guide'>Download the <a href='https://github.com/eth-clients/holesky/blob/main/custom_config_data/genesis.ssz'>Holesky genesis state from Github</a> into your <code>consensus/prysm</code> directory. Then use the following command to start a beacon node that connects to your local execution node:</p>
+        <p className='hidden-in-jwt-guide'>Download the <a href='https://github.com/eth-clients/holesky/blob/main/custom_config_data/genesis.ssz'>Holesky genesis state from Github</a> into your <code>consensus</code> directory. Then use the following command to start a beacon node that connects to your local execution node by replacing <code>&lt;PATH_TO_IPC_FILE&gt;</code> by the path to the IPC file the execution client created for you during the previous step:</p>
         <Tabs groupId="protocol" defaultValue="jwt" values={[
-            {label: 'JWT', value: 'jwt'},
-            {label: 'IPC', value: 'ipc'}
-            ]}>
-                <TabItem value="jwt"><pre><code>./prysm.sh beacon-chain --execution-endpoint=http://localhost:8551 --holesky --suggested-fee-recipient=0x01234567722E6b0000012BFEBf6177F1D2e9758D9 --jwt-secret=jwt.hex --genesis-state=genesis.ssz</code></pre></TabItem>
-                <TabItem value="ipc"><pre><code>./prysm.sh beacon-chain --execution-endpoint=$HOME/.ethereum/&lt;your.ipc&gt; --holesky --suggested-fee-recipient=0x01234567722E6b0000012BFEBf6177F1D2e9758D9 --genesis-state=genesis.ssz</code></pre></TabItem>
-            </Tabs>
+          {label: 'JWT', value: 'jwt'},
+          {label: 'IPC', value: 'ipc'}
+        ]}>
+          <TabItem value="jwt"><pre><code>./prysm.sh beacon-chain --execution-endpoint=http://localhost:8551 --holesky --jwt-secret=&lt;PATH_TO_JWT_FILE&gt; --genesis-state=genesis.ssz</code></pre></TabItem>
+          <TabItem value="ipc"><pre><code>./prysm.sh beacon-chain --execution-endpoint=&lt;PATH_TO_IPC_FILE&gt; --holesky --genesis-state=genesis.ssz</code></pre></TabItem>
+        </Tabs>
       </TabItem>
     </Tabs>
   </TabItem>
@@ -117,10 +121,12 @@ import TabItem from '@theme/TabItem';
 
 <div className='hidden-in-jwt-guide hidden-in-mergeprep-guide'>
 
-If you're running a validator, specifying a <code>suggested-fee-recipient</code> wallet address will allow you to earn what were previously miner transaction fee tips. See [How to configure Fee Recipient](../../execution-node/fee-recipient.md) for more information about this feature.
+If you are plannig to run a validator, it is <strong>strongly</strong> advised to use the <code>--suggested-fee-recipient=<WALLET ADDRESS\></code> option. When your validator proposes a block, it will allow you to earn block priority fees, also sometimes called "tips". See [How to configure Fee Recipient](../../execution-node/fee-recipient.md) for more information about this feature.
 
-Your beacon node will now begin syncing. This usually takes a couple days, but it can take longer depending on your network and hardware specs.
+Your beacon node will now begin syncing from genesis. This usually takes a couple days, but it can take longer depending on your network and hardware specs.
 
-<p className="hidden-in-mergeprep-guide">Congratulations - you’re now running a <strong>full, Merge-ready Ethereum node</strong>. To check the status of your node, visit <a href='https://docs.prylabs.network/docs/monitoring/checking-status'>Check node and validator status</a>.</p>
+It is also possible to sync your beacon node from a checkpoint. This option is considered safer, and will allow your beacon node to sync considerably faster. See [Sync from a checkpoint](../../prysm-usage/checkpoint-sync.md) for more information about this feature.
+
+<p className="hidden-in-mergeprep-guide">Congratulations - you’re now running a <strong>full Ethereum node</strong>. To check the status of your node, visit <a href='https://docs.prylabs.network/docs/monitoring/checking-status'>Check node and validator status</a>.</p>
 
 </div>

--- a/website/docs/install/partials/_quickstart-run-execution-node.md
+++ b/website/docs/install/partials/_quickstart-run-execution-node.md
@@ -8,57 +8,121 @@ import TabItem from '@theme/TabItem';
     {label: 'Geth', value: 'geth'}
     ]}>
   <TabItem value="nethermind">
-   <p className='hidden-in-jwt-guide hidden-in-mergeprep-guide'>Download the latest stable release of Nethermind for your operating system from the <a href='https://downloads.nethermind.io/'>Nethermind downloads page</a>. Extract the contents into your <code>execution</code> folder. Run the following command to start your execution node:</p>
-    <Tabs groupId="network" defaultValue="mainnet" values={[
-        {label: 'Mainnet', value: 'mainnet'},
-        {label: 'Goerli-Prater', value: 'goerli-prater'},
-        {label: 'Sepolia', value: 'sepolia'},
-        {label: 'Holesky', value: 'holesky'},
+    <p className='hidden-in-jwt-guide hidden-in-mergeprep-guide'>Download the latest stable release of Nethermind for your operating system from the <a href='https://downloads.nethermind.io/'>Nethermind downloads page</a>.</p>
+    <Tabs className='tabs-hidden-in-jwt-guide'  groupId="protocol" defaultValue="jwt" values={[
+    {label: 'JWT', value: 'jwt'},
+    {label: 'IPC', value: 'ipc'}
     ]}>
-      <TabItem value="mainnet">
-        <Tabs className='tabs-hidden-in-jwt-guide' groupId="protocol" defaultValue="jwt" values={[
-            {label: 'JWT', value: 'jwt'},
-            {label: 'IPC', value: 'ipc'}
-            ]}>
-                <TabItem value="jwt"><pre><code>Nethermind.Runner --JsonRpc.Enabled true --HealthChecks.Enabled true --HealthChecks.UIEnabled true --JsonRpc.JwtSecretFile=/path/to/jwt.hex</code></pre></TabItem>
-                <TabItem value="ipc"><pre><code>Nethermind.Runner --JsonRpc.Enabled true --HealthChecks.Enabled true --HealthChecks.UIEnabled true --JsonRpc.IpcUnixDomainSocketPath=/path/to/&lt;your.ipc&gt;</code></pre></TabItem>
-            </Tabs>
+      <TabItem value="jwt">
+        <p>Extract the contents into your <code>execution</code> folder. Run the following command to start your execution node by replacing <code>&lt;PATH_TO_JWT_FILE&gt;</code> by the path to the JWT file generated during the previous step:</p>
       </TabItem>
-      <TabItem value="goerli-prater">
-          <Tabs className='tabs-hidden-in-jwt-guide' groupId="protocol" defaultValue="jwt" values={[
-            {label: 'JWT', value: 'jwt'},
-            {label: 'IPC', value: 'ipc'}
-            ]}>
-                <TabItem value="jwt"><pre><code>Nethermind.Runner --config goerli --JsonRpc.Enabled true  --HealthChecks.Enabled true --HealthChecks.UIEnabled true --JsonRpc.JwtSecretFile=/path/to/jwt.hex</code></pre></TabItem>
-                <TabItem value="ipc"><pre><code>Nethermind.Runner --config goerli --JsonRpc.Enabled true  --HealthChecks.Enabled true --HealthChecks.UIEnabled true --JsonRpc.IpcUnixDomainSocketPath=/path/to/&lt;your.ipc&gt;</code></pre></TabItem>
-            </Tabs>
-      </TabItem>
-      <TabItem value="sepolia">
-        <Tabs className='tabs-hidden-in-jwt-guide' groupId="protocol" defaultValue="jwt" values={[
-            {label: 'JWT', value: 'jwt'},
-            {label: 'IPC', value: 'ipc'}
-            ]}>
-                <TabItem value="jwt"><pre><code>Nethermind.Runner --config sepolia --JsonRpc.Enabled true --HealthChecks.Enabled true --HealthChecks.UIEnabled true --JsonRpc.JwtSecretFile=/path/to/jwt.hex --Merge.TerminalTotalDifficulty 17000000000000000</code></pre></TabItem>
-                <TabItem value="ipc"><pre><code>Nethermind.Runner --config sepolia --JsonRpc.Enabled true --HealthChecks.Enabled true --HealthChecks.UIEnabled true --JsonRpc.IpcUnixDomainSocketPath=/path/to/&lt;your.ipc&gt; --Merge.TerminalTotalDifficulty 17000000000000000</code></pre></TabItem>
-            </Tabs>
-      </TabItem>
-      <TabItem value="holesky">
-        <Tabs className='tabs-hidden-in-jwt-guide' groupId="protocol" defaultValue="jwt" values={[
-            {label: 'JWT', value: 'jwt'},
-            {label: 'IPC', value: 'ipc'}
-            ]}>
-                <TabItem value="jwt"><pre><code>Nethermind.Runner --config holesky --JsonRpc.Enabled true --HealthChecks.Enabled true --HealthChecks.UIEnabled true --JsonRpc.JwtSecretFile=/path/to/jwt.hex</code></pre></TabItem>
-                <TabItem value="ipc"><pre><code>Nethermind.Runner --config holesky --JsonRpc.Enabled true --HealthChecks.Enabled true --HealthChecks.UIEnabled true --JsonRpc.IpcUnixDomainSocketPath=/path/to/&lt;your.ipc&gt;</code></pre></TabItem>
-            </Tabs>
+      <TabItem value="ipc">
+        <p>Extract the contents into your <code>execution</code> folder. Run the following command to start your execution by replacing <code>&lt;PATH_TO_IPC_FILE&gt;</code> by any empty path on your file system. The execution layer client will create an IPC file at this location:</p>
       </TabItem>
     </Tabs>
+      <Tabs groupId="os" defaultValue="others" values={[
+      {label: 'Windows', value: 'win'},
+      {label: 'Linux, MacOS, Arm64', value: 'others'}
+      ]}>
+        <TabItem value="win">        
+          <Tabs groupId="network" defaultValue="mainnet" values={[
+            {label: 'Mainnet', value: 'mainnet'},
+            {label: 'Goerli', value: 'goerli'},
+            {label: 'Sepolia', value: 'sepolia'},
+            {label: 'Holesky', value: 'holesky'},
+          ]}>
+            <TabItem value="mainnet">
+              <Tabs className='tabs-hidden-in-jwt-guide' groupId="protocol" defaultValue="jwt" values={[
+                {label: 'JWT', value: 'jwt'},
+                {label: 'IPC', value: 'ipc'}
+              ]}>
+                <TabItem value="jwt"><pre><code>Nethermind.Runner --config mainnet --JsonRpc.Enabled true --HealthChecks.Enabled true --HealthChecks.UIEnabled true --JsonRpc.JwtSecretFile=&lt;PATH_TO_JWT_FILE&gt;</code></pre></TabItem>
+                <TabItem value="ipc"><pre><code>Nethermind.Runner --config mainnet --JsonRpc.Enabled true --HealthChecks.Enabled true --HealthChecks.UIEnabled true --JsonRpc.IpcUnixDomainSocketPath=&lt;PATH_TO_IPC_FILE&gt;</code></pre></TabItem>
+              </Tabs>
+            </TabItem>
+            <TabItem value="goerli">
+                <Tabs className='tabs-hidden-in-jwt-guide' groupId="protocol" defaultValue="jwt" values={[
+                  {label: 'JWT', value: 'jwt'},
+                  {label: 'IPC', value: 'ipc'}
+                  ]}>
+                      <TabItem value="jwt"><pre><code>Nethermind.Runner --config goerli --JsonRpc.Enabled true  --HealthChecks.Enabled true --HealthChecks.UIEnabled true --JsonRpc.JwtSecretFile=&lt;PATH_TO_JWT_FILE&gt</code></pre></TabItem>
+                      <TabItem value="ipc"><pre><code>Nethermind.Runner --config goerli --JsonRpc.Enabled true  --HealthChecks.Enabled true --HealthChecks.UIEnabled true --JsonRpc.IpcUnixDomainSocketPath=&lt;PATH_TO_IPC_FILE&gt;</code></pre></TabItem>
+                  </Tabs>
+            </TabItem>
+            <TabItem value="sepolia">
+              <Tabs className='tabs-hidden-in-jwt-guide' groupId="protocol" defaultValue="jwt" values={[
+                  {label: 'JWT', value: 'jwt'},
+                  {label: 'IPC', value: 'ipc'}
+                  ]}>
+                      <TabItem value="jwt"><pre><code>Nethermind.Runner --config sepolia --JsonRpc.Enabled true --HealthChecks.Enabled true --HealthChecks.UIEnabled true--JsonRpc.JwtSecretFile=&lt;PATH_TO_JWT_FILE&gt</code></pre></TabItem>
+                      <TabItem value="ipc"><pre><code>Nethermind.Runner --config sepolia --JsonRpc.Enabled true --HealthChecks.Enabled true --HealthChecks.UIEnabled true --JsonRpc.IpcUnixDomainSocketPath=&lt;PATH_TO_IPC_FILE&gt;</code></pre></TabItem>
+                  </Tabs>
+            </TabItem>
+            <TabItem value="holesky">
+              <Tabs className='tabs-hidden-in-jwt-guide' groupId="protocol" defaultValue="jwt" values={[
+                  {label: 'JWT', value: 'jwt'},
+                  {label: 'IPC', value: 'ipc'}
+                  ]}>
+                      <TabItem value="jwt"><pre><code>Nethermind.Runner --config holesky --JsonRpc.Enabled true --HealthChecks.Enabled true --HealthChecks.UIEnabled true--JsonRpc.JwtSecretFile=&lt;PATH_TO_JWT_FILE&gt;</code></pre></TabItem>
+                      <TabItem value="ipc"><pre><code>Nethermind.Runner --config holesky --JsonRpc.Enabled true --HealthChecks.Enabled true --HealthChecks.UIEnabled true --JsonRpc.IpcUnixDomainSocketPath=/path/to/&lt;your.ipc&gt;</code></pre></TabItem>
+                  </Tabs>
+            </TabItem>
+          </Tabs>
+        </TabItem>
+        <TabItem value="others">        
+          <Tabs groupId="network" defaultValue="mainnet" values={[
+            {label: 'Mainnet', value: 'mainnet'},
+            {label: 'Goerli', value: 'goerli'},
+            {label: 'Sepolia', value: 'sepolia'},
+            {label: 'Holesky', value: 'holesky'},
+          ]}>
+            <TabItem value="mainnet">
+              <Tabs className='tabs-hidden-in-jwt-guide' groupId="protocol" defaultValue="jwt" values={[
+                {label: 'JWT', value: 'jwt'},
+                {label: 'IPC', value: 'ipc'}
+              ]}>
+                <TabItem value="jwt"><pre><code>./Nethermind.Runner --config mainnet --JsonRpc.Enabled true --HealthChecks.Enabled true --HealthChecks.UIEnabled true --JsonRpc.JwtSecretFile=&lt;PATH_TO_JWT_FILE&gt;</code></pre></TabItem>
+                <TabItem value="ipc"><pre><code>./Nethermind.Runner --config mainnet --JsonRpc.Enabled true --HealthChecks.Enabled true --HealthChecks.UIEnabled true --JsonRpc.IpcUnixDomainSocketPath=&lt;PATH_TO_IPC_FILE&gt;</code></pre></TabItem>
+              </Tabs>
+            </TabItem>
+            <TabItem value="goerli">
+                <Tabs className='tabs-hidden-in-jwt-guide' groupId="protocol" defaultValue="jwt" values={[
+                  {label: 'JWT', value: 'jwt'},
+                  {label: 'IPC', value: 'ipc'}
+                  ]}>
+                      <TabItem value="jwt"><pre><code>./Nethermind.Runner --config goerli --JsonRpc.Enabled true  --HealthChecks.Enabled true --HealthChecks.UIEnabled true --JsonRpc.JwtSecretFile=&lt;PATH_TO_JWT_FILE&gt</code></pre></TabItem>
+                      <TabItem value="ipc"><pre><code>./Nethermind.Runner --config goerli --JsonRpc.Enabled true  --HealthChecks.Enabled true --HealthChecks.UIEnabled true --JsonRpc.IpcUnixDomainSocketPath=&lt;PATH_TO_IPC_FILE&gt;</code></pre></TabItem>
+                  </Tabs>
+            </TabItem>
+            <TabItem value="sepolia">
+              <Tabs className='tabs-hidden-in-jwt-guide' groupId="protocol" defaultValue="jwt" values={[
+                  {label: 'JWT', value: 'jwt'},
+                  {label: 'IPC', value: 'ipc'}
+                  ]}>
+                      <TabItem value="jwt"><pre><code>./Nethermind.Runner --config sepolia --JsonRpc.Enabled true --HealthChecks.Enabled true --HealthChecks.UIEnabled true--JsonRpc.JwtSecretFile=&lt;PATH_TO_JWT_FILE&gt</code></pre></TabItem>
+                      <TabItem value="ipc"><pre><code>./Nethermind.Runner --config sepolia --JsonRpc.Enabled true --HealthChecks.Enabled true --HealthChecks.UIEnabled true --JsonRpc.IpcUnixDomainSocketPath=&lt;PATH_TO_IPC_FILE&gt;</code></pre></TabItem>
+                  </Tabs>
+            </TabItem>
+            <TabItem value="holesky">
+              <Tabs className='tabs-hidden-in-jwt-guide' groupId="protocol" defaultValue="jwt" values={[
+                  {label: 'JWT', value: 'jwt'},
+                  {label: 'IPC', value: 'ipc'}
+                  ]}>
+                      <TabItem value="jwt"><pre><code>./Nethermind.Runner --config holesky --JsonRpc.Enabled true --HealthChecks.Enabled true --HealthChecks.UIEnabled true--JsonRpc.JwtSecretFile=&lt;PATH_TO_JWT_FILE&gt;</code></pre></TabItem>
+                      <TabItem value="ipc"><pre><code>./Nethermind.Runner --config holesky --JsonRpc.Enabled true --HealthChecks.Enabled true --HealthChecks.UIEnabled true --JsonRpc.IpcUnixDomainSocketPath=/path/to/&lt;your.ipc&gt;</code></pre></TabItem>
+                  </Tabs>
+            </TabItem>
+          </Tabs>
+        </TabItem>
+      </Tabs>
     <p>See Nethermind's <a href='https://docs.nethermind.io/nethermind/ethereum-client/configuration'>command-line options</a> for parameter definitions.</p>
   </TabItem>
   <TabItem value="besu">
-    <p className='hidden-in-jwt-guide hidden-in-mergeprep-guide'>Ensure that the latest 64-bit version of the <a href='https://www.oracle.com/java/technologies/downloads/'>Java JDK</a> is installed. Download the latest stable release of Besu from the <a href='https://github.com/hyperledger/besu/releases'>Besu releases</a> page. OS-specific instructions are available on Besu's <a href='https://besu.hyperledger.org/en/stable/HowTo/Get-Started/Installation-Options/Install-Binaries/'>binary installation page</a>. Run the following command to start your execution node:</p>
+    <p className='hidden-in-jwt-guide hidden-in-mergeprep-guide'>Ensure that the latest 64-bit version of the <a href='https://www.oracle.com/java/technologies/downloads/'>Java JDK</a> is installed. Download the latest stable release of Besu from the <a href='https://github.com/hyperledger/besu/releases'>Besu releases</a> page. OS-specific instructions are available on Besu's <a href='https://besu.hyperledger.org/public-networks/get-started/install/binary-distribution'>binary installation page</a>.</p>
+    <p>Run the following command to start your execution node replacing <code>&lt;PATH_TO_JWT_FILE&gt;</code> by the path to the JWT file generated during the previous step:</p>
     <Tabs groupId="network" defaultValue="mainnet" values={[
         {label: 'Mainnet', value: 'mainnet'},
-        {label: 'Goerli-Prater', value: 'goerli-prater'},
+        {label: 'Goerli', value: 'goerli'},
         {label: 'Sepolia', value: 'sepolia'},
         {label: 'Holesky', value: 'holesky'},
     ]}>
@@ -67,16 +131,16 @@ import TabItem from '@theme/TabItem';
             {label: 'JWT', value: 'jwt'},
             {label: 'IPC', value: 'ipc'}
             ]}>
-                <TabItem value="jwt"><pre><code>besu --rpc-http-enabled --engine-jwt-enabled=true --engine-jwt-secret=path/to/jwt.hex  --engine-host-allowlist="*"</code></pre></TabItem>
+                <TabItem value="jwt"><pre><code>besu --network=mainnet --rpc-http-enabled --engine-jwt-enabled=true --engine-jwt-secret=&lt;PATH_TO_JWT_FILE&gt; --engine-host-allowlist="*"</code></pre></TabItem>
                 <TabItem value="ipc"><div className="admonition admonition-danger alert alert--info"><div className="admonition-content"><p>Content under construction.</p></div></div></TabItem>
             </Tabs>
       </TabItem>
-      <TabItem value="goerli-prater">
+      <TabItem value="goerli">
         <Tabs className='tabs-hidden-in-jwt-guide'  groupId="protocol" defaultValue="jwt" values={[
             {label: 'JWT', value: 'jwt'},
             {label: 'IPC', value: 'ipc'}
             ]}>
-                <TabItem value="jwt"><pre><code>besu --network=goerli --rpc-http-enabled --engine-jwt-enabled=true --engine-jwt-secret=path/to/jwt.hex  --engine-host-allowlist="*"</code></pre></TabItem>
+                <TabItem value="jwt"><pre><code>besu --network=goerli --rpc-http-enabled --engine-jwt-enabled=true --engine-jwt-secret=&lt;PATH_TO_JWT_FILE&gt; --engine-host-allowlist="*"</code></pre></TabItem>
                 <TabItem value="ipc"><div className="admonition admonition-danger alert alert--info"><div className="admonition-content"><p>Content under construction.</p></div></div></TabItem>
             </Tabs>
       </TabItem>
@@ -85,7 +149,7 @@ import TabItem from '@theme/TabItem';
             {label: 'JWT', value: 'jwt'},
             {label: 'IPC', value: 'ipc'}
             ]}>
-                <TabItem value="jwt"><pre><code>besu --network=sepolia --rpc-http-enabled --engine-jwt-enabled=true --engine-jwt-secret=/path/to/jwt.hex --engine-host-allowlist="*" --override-genesis-config="terminalTotalDifficulty=17000000000000000"</code></pre></TabItem>
+                <TabItem value="jwt"><pre><code>besu --network=sepolia --rpc-http-enabled --engine-jwt-enabled=true --engine-jwt-secret=&lt;PATH_TO_JWT_FILE&gt; --engine-host-allowlist="*"</code></pre></TabItem>
                 <TabItem value="ipc"><div className="admonition admonition-danger alert alert--info"><div className="admonition-content"><p>Content under construction.</p></div></div></TabItem>
             </Tabs>
       </TabItem>
@@ -94,7 +158,7 @@ import TabItem from '@theme/TabItem';
             {label: 'JWT', value: 'jwt'},
             {label: 'IPC', value: 'ipc'}
             ]}>
-                <TabItem value="jwt"><pre><code>besu --network=holesky --rpc-http-enabled --engine-jwt-enabled=true --engine-jwt-secret=/path/to/jwt.hex --engine-host-allowlist="*"</code></pre></TabItem>
+                <TabItem value="jwt"><pre><code>besu --network=holesky --rpc-http-enabled --engine-jwt-enabled=true --engine-jwt-secret=&lt;PATH_TO_JWT_FILE&gt; --engine-host-allowlist="*"</code></pre></TabItem>
                 <TabItem value="ipc"><div className="admonition admonition-danger alert alert--info"><div className="admonition-content"><p>Content under construction.</p></div></div></TabItem>
             </Tabs>
       </TabItem>
@@ -102,54 +166,117 @@ import TabItem from '@theme/TabItem';
     <p>See Besu's <a href='https://besu.hyperledger.org/en/stable/Reference/CLI/CLI-Syntax/'>command-line options</a> for parameter definitions.</p>
   </TabItem>
   <TabItem value="geth">
-    <p className='hidden-in-jwt-guide hidden-in-mergeprep-guide'>Download and run the latest 64-bit stable release of the <strong>Geth installer</strong> for your operating system from the <a href='https://geth.ethereum.org/downloads/'>Geth downloads page</a>.</p>
-    <p className='hidden-in-jwt-guide hidden-in-mergeprep-guide'>Navigate to your <code>execution</code> directory and run the following command to start your execution node:</p>
-    <Tabs groupId="network" defaultValue="mainnet" values={[
-        {label: 'Mainnet', value: 'mainnet'},
-        {label: 'Goerli-Prater', value: 'goerli-prater'},
-        {label: 'Sepolia', value: 'sepolia'},
-        {label: 'Holesky', value: 'holesky'},
-    ]}>
-      <TabItem value="mainnet">
-        <Tabs className='tabs-hidden-in-jwt-guide'  groupId="protocol" defaultValue="jwt" values={[
-            {label: 'JWT', value: 'jwt'},
-            {label: 'IPC', value: 'ipc'}
-            ]}>
-                <TabItem value="jwt"><pre><code>geth --http --http.api eth,net,engine,admin --authrpc.jwtsecret /path/to/jwt.hex </code></pre></TabItem>
-                <TabItem value="ipc"><pre><code>geth --http --http.api eth,net,engine,admin </code></pre></TabItem>
-            </Tabs>
+    <p className='hidden-in-jwt-guide hidden-in-mergeprep-guide'>Download and run the latest 64-bit stable release of <strong>Geth</strong> for your operating system from the <a href='https://geth.ethereum.org/downloads/'>Geth downloads page</a>.</p> 
+    <p>Move the <code>geth</code> executable into your <code>execution</code> directory.</p>
+    <Tabs className='tabs-hidden-in-jwt-guide'  groupId="protocol" defaultValue="jwt" values={[
+        {label: 'JWT', value: 'jwt'},
+        {label: 'IPC', value: 'ipc'}
+        ]}>
+      <TabItem value="jwt">
+        <p className='hidden-in-jwt-guide hidden-in-mergeprep-guide'>Navigate to your <code>execution</code> directory and run the following command to start your execution node by replacing <code>&lt;PATH_TO_JWT_FILE&gt;</code> by the path to the JWT file generated during the previous step:</p>
       </TabItem>
-      <TabItem value="goerli-prater">
-        <Tabs className='tabs-hidden-in-jwt-guide'  groupId="protocol" defaultValue="jwt" values={[
-            {label: 'JWT', value: 'jwt'},
-            {label: 'IPC', value: 'ipc'}
-            ]}>
-                <TabItem value="jwt"><pre><code>geth --goerli --http --http.api eth,net,engine,admin --authrpc.jwtsecret /path/to/jwt.hex </code></pre></TabItem>
-                <TabItem value="ipc"><pre><code>geth --goerli --http --http.api eth,net,engine,admin </code></pre></TabItem>
-            </Tabs>
-      </TabItem>
-      <TabItem value="sepolia">
-        <Tabs className='tabs-hidden-in-jwt-guide'  groupId="protocol" defaultValue="jwt" values={[
-            {label: 'JWT', value: 'jwt'},
-            {label: 'IPC', value: 'ipc'}
-            ]}>
-                <TabItem value="jwt"><pre><code>geth --sepolia --http --http.api eth,net,engine,admin --authrpc.jwtsecret /path/to/jwt.hex</code></pre></TabItem>
-                <TabItem value="ipc"><pre><code>geth --sepolia --http --http.api eth,net,engine,admin</code></pre></TabItem>
-            </Tabs>
-      </TabItem>
-      <TabItem value="holesky">
-        <Tabs className='tabs-hidden-in-jwt-guide'  groupId="protocol" defaultValue="jwt" values={[
-            {label: 'JWT', value: 'jwt'},
-            {label: 'IPC', value: 'ipc'}
-            ]}>
-                <TabItem value="jwt"><pre><code>geth --holesky --http --http.api eth,net,engine,admin --authrpc.jwtsecret /path/to/jwt.hex</code></pre></TabItem>
-                <TabItem value="ipc"><pre><code>geth --holesky --http --http.api eth,net,engine,admin</code></pre></TabItem>
-            </Tabs>
+      <TabItem value="ipc">
+        <p className='hidden-in-jwt-guide hidden-in-mergeprep-guide'>Navigate to your <code>execution</code> directory and run the following command to start your execution node by replacing <code>&lt;PATH_TO_IPC_FILE&gt;</code> by any empty path on your file system. The execution layer client will create an IPC file at this location:</p>
       </TabItem>
     </Tabs>
-    <p>See Geth's <a href='https://geth.ethereum.org/docs/interface/command-line-options'>command-line options</a> for parameter definitions.</p>
+    <Tabs groupId="os" defaultValue="others" values={[
+    {label: 'Windows', value: 'win'},
+    {label: 'Linux, MacOS, Arm64', value: 'others'}
+    ]}>
+      <TabItem value="win">
+        <Tabs groupId="network" defaultValue="mainnet" values={[
+            {label: 'Mainnet', value: 'mainnet'},
+            {label: 'Goerli', value: 'goerli'},
+            {label: 'Sepolia', value: 'sepolia'},
+            {label: 'Holesky', value: 'holesky'},
+        ]}>
+          <TabItem value="mainnet">
+            <Tabs className='tabs-hidden-in-jwt-guide'  groupId="protocol" defaultValue="jwt" values={[
+                {label: 'JWT', value: 'jwt'},
+                {label: 'IPC', value: 'ipc'}
+                ]}>
+                    <TabItem value="jwt"><pre><code>geth --mainnet --http --http.api eth,net,engine,admin --authrpc.jwtsecret=&lt;PATH_TO_JWT_FILE&gt; </code></pre></TabItem>
+                    <TabItem value="ipc"><pre><code>geth --mainnet --http --http.api eth,net,engine,admin --ipcpath=&lt;PATH_TO_IPC_FILE&gt;</code></pre></TabItem>
+            </Tabs>
+          </TabItem>
+          <TabItem value="goerli">
+            <Tabs className='tabs-hidden-in-jwt-guide'  groupId="protocol" defaultValue="jwt" values={[
+                {label: 'JWT', value: 'jwt'},
+                {label: 'IPC', value: 'ipc'}
+                ]}>
+                    <TabItem value="jwt"><pre><code>geth --goerli --http --http.api eth,net,engine,admin --authrpc.jwtsecret=&lt;PATH_TO_JWT_FILE&gt; </code></pre></TabItem>
+                    <TabItem value="ipc"><pre><code>geth --goerli --http --http.api eth,net,engine,admin --ipcpath=&lt;PATH_TO_IPC_FILE&gt;</code></pre></TabItem>
+            </Tabs>
+          </TabItem>
+          <TabItem value="sepolia">
+            <Tabs className='tabs-hidden-in-jwt-guide'  groupId="protocol" defaultValue="jwt" values={[
+                {label: 'JWT', value: 'jwt'},
+                {label: 'IPC', value: 'ipc'}
+                ]}>
+                    <TabItem value="jwt"><pre><code>geth --sepolia --http --http.api eth,net,engine,admin --authrpc.jwtsecret=&lt;PATH_TO_JWT_FILE&gt;</code></pre></TabItem>
+                    <TabItem value="ipc"><pre><code>geth --sepolia --http --http.api eth,net,engine,admin --ipcpath=&lt;PATH_TO_IPC_FILE&gt;</code></pre></TabItem>
+            </Tabs>
+          </TabItem>
+          <TabItem value="holesky">
+            <Tabs className='tabs-hidden-in-jwt-guide'  groupId="protocol" defaultValue="jwt" values={[
+                {label: 'JWT', value: 'jwt'},
+                {label: 'IPC', value: 'ipc'}
+                ]}>
+                    <TabItem value="jwt"><pre><code>geth --holesky --http --http.api eth,net,engine,admin --authrpc.jwtsecret=&lt;PATH_TO_JWT_FILE&gt;</code></pre></TabItem>
+                    <TabItem value="ipc"><pre><code>geth --holesky --http --http.api eth,net,engine,admin --ipcpath=&lt;PATH_TO_IPC_FILE&gt;</code></pre></TabItem>
+            </Tabs>
+          </TabItem>
+        </Tabs>
+      </TabItem>
+      <TabItem value="others">
+        <Tabs groupId="network" defaultValue="mainnet" values={[
+            {label: 'Mainnet', value: 'mainnet'},
+            {label: 'Goerli', value: 'goerli'},
+            {label: 'Sepolia', value: 'sepolia'},
+            {label: 'Holesky', value: 'holesky'},
+        ]}>
+          <TabItem value="mainnet">
+            <Tabs className='tabs-hidden-in-jwt-guide'  groupId="protocol" defaultValue="jwt" values={[
+                {label: 'JWT', value: 'jwt'},
+                {label: 'IPC', value: 'ipc'}
+                ]}>
+                    <TabItem value="jwt"><pre><code>./geth --mainnet --http --http.api eth,net,engine,admin --authrpc.jwtsecret=&lt;PATH_TO_JWT_FILE&gt; </code></pre></TabItem>
+                    <TabItem value="ipc"><pre><code>./geth --mainnet --http --http.api eth,net,engine,admin --ipcpath=&lt;PATH_TO_IPC_FILE&gt;</code></pre></TabItem>
+            </Tabs>
+          </TabItem>
+          <TabItem value="goerli">
+            <Tabs className='tabs-hidden-in-jwt-guide'  groupId="protocol" defaultValue="jwt" values={[
+                {label: 'JWT', value: 'jwt'},
+                {label: 'IPC', value: 'ipc'}
+                ]}>
+                    <TabItem value="jwt"><pre><code>./geth --goerli --http --http.api eth,net,engine,admin --authrpc.jwtsecret=&lt;PATH_TO_JWT_FILE&gt; </code></pre></TabItem>
+                    <TabItem value="ipc"><pre><code>./geth --goerli --http --http.api eth,net,engine,admin --ipcpath=&lt;PATH_TO_IPC_FILE&gt;</code></pre></TabItem>
+            </Tabs>
+          </TabItem>
+          <TabItem value="sepolia">
+            <Tabs className='tabs-hidden-in-jwt-guide'  groupId="protocol" defaultValue="jwt" values={[
+                {label: 'JWT', value: 'jwt'},
+                {label: 'IPC', value: 'ipc'}
+                ]}>
+                    <TabItem value="jwt"><pre><code>./geth --sepolia --http --http.api eth,net,engine,admin --authrpc.jwtsecret=&lt;PATH_TO_JWT_FILE&gt;</code></pre></TabItem>
+                    <TabItem value="ipc"><pre><code>./geth --sepolia --http --http.api eth,net,engine,admin --ipcpath=&lt;PATH_TO_IPC_FILE&gt;</code></pre></TabItem>
+            </Tabs>
+          </TabItem>
+          <TabItem value="holesky">
+            <Tabs className='tabs-hidden-in-jwt-guide'  groupId="protocol" defaultValue="jwt" values={[
+                {label: 'JWT', value: 'jwt'},
+                {label: 'IPC', value: 'ipc'}
+                ]}>
+                    <TabItem value="jwt"><pre><code>./geth --holesky --http --http.api eth,net,engine,admin --authrpc.jwtsecret=&lt;PATH_TO_JWT_FILE&gt;</code></pre></TabItem>
+                    <TabItem value="ipc"><pre><code>./geth --holesky --http --http.api eth,net,engine,admin --ipcpath=&lt;PATH_TO_IPC_FILE&gt;</code></pre></TabItem>
+            </Tabs>
+          </TabItem>
+        </Tabs>
+      </TabItem>
+      <p>See Geth's <a href='https://geth.ethereum.org/docs/interface/command-line-options'>command-line options</a> for parameter definitions.</p>
+    </Tabs>
   </TabItem>
 </Tabs>
 
-Syncing can take a long time - from hours to days. <span className='hidden-in-jwt-guide hidden-in-execution-guide'>You can proceed to the next step while your execution node syncs.</span>
+The execution layer client cannot sync without an attached beacon node. We'll see how to setup a beacon node in the next step.
 

--- a/website/docs/install/partials/_quickstart-run-validator.md
+++ b/website/docs/install/partials/_quickstart-run-validator.md
@@ -3,116 +3,209 @@ import TabItem from '@theme/TabItem';
 
 Next, we'll create your validator keys with the [Ethereum Staking Deposit CLI](https://github.com/ethereum/staking-deposit-cli).
 
-Download the latest stable version of the deposit CLI from the [Staking Deposit CLI Releases page](https://github.com/ethereum/staking-deposit-cli/releases).
+Download - ideally on a new machine that has never been connected to the internet - the latest stable version of the deposit CLI from the [Staking Deposit CLI Releases page](https://github.com/ethereum/staking-deposit-cli/releases).
+
+Run the following command to create your mnemonic (a unique and <strong>highly sensitive</strong> 24-word phrase) and keys:
+<Tabs groupId="os" defaultValue="others" values={[
+    {label: 'Windows', value: 'win'},
+    {label: 'Linux, MacOS, Arm64', value: 'others'}
+]}>
+  <TabItem value="win">
+    <Tabs groupId="network" defaultValue="mainnet" values={[
+        {label: 'Mainnet', value: 'mainnet'},
+        {label: 'Goerli', value: 'goerli'},
+        {label: 'Sepolia', value: 'sepolia'},
+        {label: 'Holesky', value: 'holesky'},
+    ]}>
+      <TabItem value="mainnet">
+        <pre><code>deposit.exe new-mnemonic --num_validators=1 --mnemonic_language=english --chain=mainnet</code></pre>
+      </TabItem>
+      <TabItem value="goerli">
+        <pre><code>deposit.exe new-mnemonic --num_validators=1 --mnemonic_language=english --chain=goerli</code></pre>
+      </TabItem>
+      <TabItem value="sepolia">
+        <pre><code>deposit.exe new-mnemonic --num_validators=1 --mnemonic_language=english --chain=sepolia</code></pre>
+      </TabItem>
+      <TabItem value="holesky">
+        <pre><code>deposit.exe new-mnemonic --num_validators=1 --mnemonic_language=english --chain=holesky</code></pre>
+      </TabItem>
+    </Tabs>
+  </TabItem>
+  <TabItem value="others">
+    <Tabs groupId="network" defaultValue="mainnet" values={[
+        {label: 'Mainnet', value: 'mainnet'},
+        {label: 'Goerli', value: 'goerli'},
+        {label: 'Sepolia', value: 'sepolia'},
+        {label: 'Holesky', value: 'holesky'},
+    ]}>
+      <TabItem value="mainnet">
+        <pre><code>./deposit new-mnemonic --num_validators=1 --mnemonic_language=english --chain=mainnet</code></pre>
+      </TabItem>
+      <TabItem value="goerli">
+        <pre><code>./deposit new-mnemonic --num_validators=1 --mnemonic_language=english --chain=goerli</code></pre>
+      </TabItem>
+      <TabItem value="sepolia">
+        <pre><code>./deposit new-mnemonic --num_validators=1 --mnemonic_language=english --chain=sepolia</code></pre>
+      </TabItem>
+      <TabItem value="holesky">
+        <pre><code>./deposit new-mnemonic --num_validators=1 --mnemonic_language=english --chain=holesky</code></pre>
+      </TabItem>
+    </Tabs>
+  </TabItem>
+</Tabs>
+
+ <p>Follow the CLI prompts to generate your keys. The password you choose will be needed later when importing the generated data into the Prysm validator client. This will give you the following artifacts:</p>
+<ol>
+  <li>A <strong>new mnemonic seed phrase</strong>. This is <strong>highly sensitive</strong> and should never be exposed to other people or networked hardware.</li>
+  <li>A <code>validator_keys</code> folder. This folder will contain two files:
+    <ol>
+      <li><code>deposit_data-*.json</code> - contains deposit data that you’ll later upload to the Ethereum launchpad.</li>
+      <li><code>keystore-m_*.json</code> - contains your public key and encrypted private key.</li>
+    </ol>
+  </li>
+</ol>
+<p>If needed, copy the <code>validator_keys</code> folder to your primary machine. Run the following command to import your keystores, replacing <code>&lt;YOUR_FOLDER_PATH&gt;</code> with the full path to your <code>validator_keys</code> folder:</p>
 
 <Tabs groupId="os" defaultValue="others" values={[
     {label: 'Windows', value: 'win'},
     {label: 'Linux, MacOS, Arm64', value: 'others'}
 ]}>
   <TabItem value="win">
-    <p>Run the following command to create your mnemonic (a unique and <strong>highly sensitive</strong> 24-word phrase) and keys:</p>
     <Tabs groupId="network" defaultValue="mainnet" values={[
         {label: 'Mainnet', value: 'mainnet'},
-        {label: 'Goerli-Prater', value: 'goerli-prater'},
+        {label: 'Goerli', value: 'goerli'},
+        {label: 'Sepolia', value: 'sepolia'},
+        {label: 'Holesky', value: 'holesky'},
     ]}>
       <TabItem value="mainnet">
-        <pre><code>deposit.exe new-mnemonic --num_validators=1 --mnemonic_language=english</code></pre>
+        <pre><code>prysm.bat validator accounts import --keys-dir=&lt;YOUR_FOLDER_PATH&gt; --mainnet</code></pre>
       </TabItem>
-      <TabItem value="goerli-prater">
-        <pre><code>deposit.exe new-mnemonic --num_validators=1 --mnemonic_language=english --chain=prater</code></pre>
+      <TabItem value="goerli">
+        <pre><code>prysm.bat validator accounts import --keys-dir=&lt;YOUR_FOLDER_PATH&gt; --goerli</code></pre>
       </TabItem>
-    </Tabs>
-    <p>Follow the CLI prompts to generate your keys. This will give you the following artifacts:</p>
-    <ol>
-      <li>A <strong>new mnemonic seed phrase</strong>. This is <strong>highly sensitive</strong> and should never be exposed to other people or networked hardware.</li>
-      <li>A <code>validator_keys</code> folder. This folder will contain two files:
-        <ol>
-          <li><code>deposit_data-*.json</code> - contains deposit data that you’ll later upload to the Ethereum launchpad.</li>
-          <li><code>keystore-m_*.json</code> - contains your public key and encrypted private key.</li>
-        </ol>
-      </li>
-    </ol>
-    <p>Copy the <code>validator_keys</code> folder to your primary machine's <code>consensus</code> folder. Run the following command to import your keystores, replacing <code>&lt;YOUR_FOLDER_PATH&gt;</code> with the full path to your <code>consensus/validator_keys</code> folder:</p>
-    <Tabs groupId="network" defaultValue="mainnet" values={[
-        {label: 'Mainnet', value: 'mainnet'},
-        {label: 'Goerli-Prater', value: 'goerli-prater'}
-    ]}>
-      <TabItem value="mainnet">
-        <pre><code>prysm.bat validator accounts import --keys-dir=&lt;YOUR_FOLDER_PATH&gt;</code></pre>
-        <p>You’ll be prompted to specify a wallet directory twice. Provide the path to your <code>consensus</code> folder for both prompts. You should see <code>Successfully imported 1 accounts, view all of them by running accounts list</code> when your account has been successfully imported into Prysm.</p>
-        <p>Next, go to the <a href='https://launchpad.ethereum.org/en/upload-deposit-data'>Mainnet Launchpad’s deposit data upload page</a> and upload your <code>deposit_data-*.json</code> file. You’ll be prompted to connect your wallet.</p>
-        <p>You can then deposit 32 ETH into the Mainnet deposit contract via the Launchpad page. Exercise extreme caution throughout this procedure.</p> 
-        <p>Finally, run the following command to start your validator, replacing <code>&lt;YOUR_FOLDER_PATH&gt;</code> with the full path to your <code>consensus/validator_keys</code> folder:</p>
-        <pre><code>prysm.bat validator --wallet-dir=&lt;YOUR_FOLDER_PATH&gt;</code></pre>
+      <TabItem value="sepolia">
+        <pre><code>prysm.bat validator accounts import --keys-dir=&lt;YOUR_FOLDER_PATH&gt; --sepolia</code></pre>
       </TabItem>
-      <TabItem value="goerli-prater">
-        <pre><code>prysm.bat validator accounts import --keys-dir=&lt;YOUR_FOLDER_PATH&gt; --prater</code></pre>
-        <p>You’ll be prompted to specify a wallet directory twice. Provide the path to your <code>consensus</code> folder for both prompts. You should see <code>Successfully imported 1 accounts, view all of them by running accounts list</code> when your account has been successfully imported into Prysm.</p>
-        <p>Next, go to the <a href='https://goerli.launchpad.ethereum.org/en/upload-deposit-data'>Goerli-Prater Launchpad’s deposit data upload page</a> and upload your <code>deposit_data-*.json</code> file. You’ll be prompted to connect your wallet.</p>
-        <p>If you need GöETH, head over to one of the following Discord servers:</p>
-        <ul>
-          <li><a href='https://discord.io/ethstaker'>r/EthStaker Discord</a></li>
-          <li><a href='https://discord.gg/prysmaticlabs'>Prysm Discord server</a></li>
-        </ul>
-        <p>Someone should be able to give you the GöETH you need. You can then deposit 32 GöETH into the Prater testnet’s deposit contract via the Launchpad page. Exercise extreme caution throughout this procedure - <strong>never send real ETH to the testnet deposit contract.</strong> Finally, run the following command to start your validator, replacing <code>&lt;YOUR_FOLDER_PATH&gt;</code> with the full path to your <code>consensus</code> folder:</p>
-        <pre><code>prysm.bat validator --wallet-dir=&lt;YOUR_FOLDER_PATH&gt; --prater</code></pre>      
+      <TabItem value="holesky">
+        <pre><code>prysm.bat validator accounts import --keys-dir=&lt;YOUR_FOLDER_PATH&gt; --holesky</code></pre>
       </TabItem>
     </Tabs>
   </TabItem>
   <TabItem value="others">
-    <p>Run the following command to create your mnemonic phrase and keys:</p>
     <Tabs groupId="network" defaultValue="mainnet" values={[
         {label: 'Mainnet', value: 'mainnet'},
-        {label: 'Goerli-Prater', value: 'goerli-prater'}
+        {label: 'Goerli', value: 'goerli'},
+        {label: 'Sepolia', value: 'sepolia'},
+        {label: 'Holesky', value: 'holesky'},
     ]}>
       <TabItem value="mainnet">
-        <pre><code>./deposit new-mnemonic --num_validators=1 --mnemonic_language=english</code></pre>
+        <pre><code>./prysm.sh validator accounts import --keys-dir=&lt;YOUR_FOLDER_PATH&gt; --mainnet</code></pre>
       </TabItem>
-      <TabItem value="goerli-prater">
-        <pre><code>./deposit new-mnemonic --num_validators=1 --mnemonic_language=english --chain=prater</code></pre>
+      <TabItem value="goerli">
+        <pre><code>./prysm.sh validator accounts import --keys-dir=&lt;YOUR_FOLDER_PATH&gt; --goerli</code></pre>
       </TabItem>
-    </Tabs>
-    <p>Follow the CLI prompts to generate your keys. This will give you the following artifacts:</p>
-    <ol>
-      <li>A <strong>new mnemonic seed phrase</strong>. This is <strong>highly sensitive</strong> and should never be exposed to other people or networked hardware.</li>
-      <li>A <code>validator_keys</code> folder. This folder will contain two files:
-        <ol>
-          <li><code>deposit_data-*.json</code> - contains deposit data that you’ll later upload to the Ethereum launchpad.</li>
-          <li><code>keystore-m_*.json</code> - contains your public key and encrypted private key.</li>
-        </ol>
-      </li>
-    </ol>
-    <p>Copy the <code>validator_keys</code> folder to your primary machine's <code>consensus</code> folder. Run the following command to import your keystores, replacing <code>&lt;YOUR_FOLDER_PATH&gt;</code> with the full path to your <code>consensus/validator_keys</code> folder:</p>
-    <Tabs groupId="network" defaultValue="mainnet" values={[
-        {label: 'Mainnet', value: 'mainnet'},
-        {label: 'Goerli-Prater', value: 'goerli-prater'}
-    ]}>
-      <TabItem value="mainnet">
-        <pre><code>./prysm.sh validator accounts import --keys-dir=&lt;YOUR_FOLDER_PATH&gt;</code></pre>
-        <p>You’ll be prompted to specify a wallet directory twice. Provide the path to your <code>consensus</code> folder for both prompts. You should see <code>Successfully imported 1 accounts, view all of them by running accounts list</code> when your account has been successfully imported into Prysm.</p>
-        <p>Next, go to the <a href='https://launchpad.ethereum.org/en/upload-deposit-data'>Mainnet Launchpad’s deposit data upload page</a> and upload your <code>deposit_data-*.json</code> file. You’ll be prompted to connect your wallet.</p>
-        <p>You can then deposit 32 ETH into the Mainnet deposit contract via the Launchpad page. Exercise extreme caution throughout this procedure. Finally, run the following command to start your validator, replacing <code>&lt;YOUR_FOLDER_PATH&gt;</code> with the full path to your <code>consensus</code> folder:</p>
-        <pre><code>./prysm.sh validator --wallet-dir=&lt;YOUR_FOLDER_PATH&gt;</code></pre>
+      <TabItem value="sepolia">
+        <pre><code>./prysm.sh validator accounts import --keys-dir=&lt;YOUR_FOLDER_PATH&gt; --sepolia</code></pre>
       </TabItem>
-      <TabItem value="goerli-prater">
-        <pre><code>./prysm.sh validator accounts import --keys-dir=&lt;YOUR_FOLDER_PATH&gt; --prater</code></pre>
-        <p>You’ll be prompted to specify a wallet directory twice. Provide the path to your <code>consensus</code> folder for both prompts. You should see <code>Successfully imported 1 accounts, view all of them by running accounts list</code> when your account has been successfully imported into Prysm.</p>
-        <p>Next, go to the <a href='https://goerli.launchpad.ethereum.org/en/upload-deposit-data'>Goerli-Prater Launchpad’s deposit data upload page</a> and upload your <code>deposit_data-*.json</code> file. You’ll be prompted to connect your wallet.</p>
-        <p>If you need GöETH, head over to one of the following Discord servers:</p>
-        <ul>
-          <li><a href='https://discord.io/ethstaker'>r/EthStaker Discord</a></li>
-          <li><a href='https://discord.gg/prysmaticlabs'>Prysm Discord server</a></li>
-        </ul>
-        <p>Someone should be able to give you the GöETH you need. You can then deposit 32 GöETH into the Prater testnet’s deposit contract via the Launchpad page. Exercise extreme caution throughout this procedure - <strong>never send real ETH to the testnet deposit contract.</strong>  Finally, run the following command to start your validator, replacing <code>&lt;YOUR_FOLDER_PATH&gt;</code> with the full path to your <code>consensus</code> folder:</p>
-        <pre><code>./prysm.sh validator --wallet-dir=&lt;YOUR_FOLDER_PATH&gt; --prater</code></pre>    
+      <TabItem value="holesky">
+        <pre><code>./prysm.sh validator accounts import --keys-dir=&lt;YOUR_FOLDER_PATH&gt; --holesky</code></pre>
       </TabItem>
     </Tabs>
   </TabItem>
 </Tabs>
 
+<p>You’ll be prompted to specify a wallet directory twice. Provide the path to your <code>consensus</code> folder for both prompts. You should see <code>Imported accounts [...] view all of them by running accounts list</code> when your account has been successfully imported into Prysm.</p>
+
+<Tabs groupId="network" defaultValue="mainnet" values={[
+        {label: 'Mainnet', value: 'mainnet'},
+        {label: 'Goerli', value: 'goerli'},
+        {label: 'Sepolia', value: 'sepolia'},
+        {label: 'Holesky', value: 'holesky'},
+]}>
+  <TabItem value="mainnet">
+    <p>Next, go to the <a href='https://launchpad.ethereum.org/en/upload-deposit-data'>Mainnet Launchpad’s deposit data upload page</a> and upload your <code>deposit_data-*.json</code> file. You’ll be prompted to connect your wallet.</p>
+    <p>You can then deposit 32 ETH into the Mainnet deposit contract via the Launchpad page. Exercise extreme caution throughout this procedure.</p>
+  </TabItem>
+  <TabItem value="goerli">
+    <p>If you need GöETH, head over to one of the following Discord servers:</p>
+    <ul>
+      <li><a href='https://discord.gg/ethstaker'>r/EthStaker Discord</a></li>
+      <li><a href='https://discord.gg/prysmaticlabs'>Prysm Discord server</a></li>
+    </ul>
+    <p>Someone should be able to give you the GöETH you need.</p>
+    <p>Next, go to the <a href='https://goerli.launchpad.ethereum.org/en/upload-deposit-data'>Goerli Launchpad’s deposit data upload page</a> and upload your <code>deposit_data-*.json</code> file. You’ll be prompted to connect your wallet.</p>
+    <p>Exercise extreme caution throughout this procedure - <strong>never send real ETH to the testnet deposit contract.</strong></p>
+  </TabItem>
+  <TabItem value="sepolia">
+    <p>Sepolia has a permissioned validators set. You cannot create a new validator on this network. If you are interested in running a validator on a testnet, please choose an other testnet, like Holesky.</p>
+  </TabItem>
+  <TabItem value="holesky">
+    <p>If you need HolETH, head over to one of the following Discord servers:</p>
+    <ul>
+      <li><a href='https://discord.gg/ethstaker'>r/EthStaker Discord</a></li>
+      <li><a href='https://discord.gg/prysmaticlabs'>Prysm Discord server</a></li>
+    </ul>
+    <p>Someone should be able to give you the HolETH you need.</p>
+    <p>Next, go to the <a href='https://holesky.launchpad.ethereum.org/en/upload-deposit-data'>Holesky Launchpad’s deposit data upload page</a> and upload your <code>deposit_data-*.json</code> file. You’ll be prompted to connect your wallet.</p>
+    <p>Exercise extreme caution throughout this procedure - <strong>never send real ETH to the testnet deposit contract.</strong></p>
+  </TabItem>
+</Tabs>
+<p>Finally, run the following command to start your validator, replacing <code>&lt;YOUR_FOLDER_PATH&gt;</code> with the full path to your <code>consensus</code> folder and <code>&lt;YOUR_WALLET_ADDRESS&gt;</code> by the adress of a wallet you own. When your validator proposes a block, it will allow you to earn block priority fees, also sometimes called "tips". See <a href='../execution-node/fee-recipient'>How to configure Fee Recipient</a> for more information about this feature:</p>
+
+<Tabs groupId="os" defaultValue="others" values={[
+    {label: 'Windows', value: 'win'},
+    {label: 'Linux, MacOS, Arm64', value: 'others'}
+]}>
+  <TabItem value="win">
+    <Tabs groupId="network" defaultValue="mainnet" values={[
+        {label: 'Mainnet', value: 'mainnet'},
+        {label: 'Goerli', value: 'goerli'},
+        {label: 'Sepolia', value: 'sepolia'},
+        {label: 'Holesky', value: 'holesky'},
+    ]}>
+      <TabItem value="mainnet">
+        <pre><code>prysm.bat validator --wallet-dir=&lt;YOUR_FOLDER_PATH&gt; --mainnet --suggested-fee-recipient=&lt;YOUR_WALLET_ADDRESS>&gt;</code></pre>
+      </TabItem>
+      <TabItem value="goerli">
+        <pre><code>prysm.bat validator --wallet-dir=&lt;YOUR_FOLDER_PATH&gt; --goerli --suggested-fee-recipient=&lt;YOUR_WALLET_ADDRESS>&gt;</code></pre>
+      </TabItem>
+      <TabItem value="sepolia">
+        <pre><code>prysm.bat validator --wallet-dir=&lt;YOUR_FOLDER_PATH&gt; --sepolia --suggested-fee-recipient=&lt;YOUR_WALLET_ADDRESS>&gt;</code></pre>
+      </TabItem>
+      <TabItem value="holesky">
+        <pre><code>prysm.bat validator --wallet-dir=&lt;YOUR_FOLDER_PATH&gt; --holesky --suggested-fee-recipient=&lt;YOUR_WALLET_ADDRESS>&gt;</code></pre>
+      </TabItem>
+    </Tabs>
+  </TabItem>
+  <TabItem value="others">
+    <Tabs groupId="network" defaultValue="mainnet" values={[
+        {label: 'Mainnet', value: 'mainnet'},
+        {label: 'Goerli', value: 'goerli'},
+        {label: 'Sepolia', value: 'sepolia'},
+        {label: 'Holesky', value: 'holesky'},
+    ]}>
+      <TabItem value="mainnet">
+        <pre><code>./prysm.sh validator --wallet-dir=&lt;YOUR_FOLDER_PATH&gt; --mainnet --suggested-fee-recipient=&lt;YOUR_WALLET_ADDRESS>&gt;</code></pre>
+      </TabItem>
+      <TabItem value="goerli">
+        <pre><code>./prysm.sh validator --wallet-dir=&lt;YOUR_FOLDER_PATH&gt; --goerli --suggested-fee-recipient=&lt;YOUR_WALLET_ADDRESS>&gt;</code></pre>
+      </TabItem>
+      <TabItem value="sepolia">
+        <pre><code>./prysm.sh validator --wallet-dir=&lt;YOUR_FOLDER_PATH&gt; --sepolia --suggested-fee-recipient=&lt;YOUR_WALLET_ADDRESS>&gt;</code></pre>
+      </TabItem>
+      <TabItem value="holesky">
+        <pre><code>./prysm.sh validator --wallet-dir=&lt;YOUR_FOLDER_PATH&gt; --holesky --suggested-fee-recipient=&lt;YOUR_WALLET_ADDRESS>&gt;</code></pre>
+      </TabItem>
+    </Tabs>
+  </TabItem>
+</Tabs>
+
+<p>You may wonder why you need to use the <code>--suggested-fee-recipient</code> in both beacon node and validator client. The reason is it is possible to plug multiple validator clients the the same beacon node. If no <code>--suggested-fee-recipient</code> is set on a validator client, then the beacon node will fallback on its own <code>--suggested-fee-recipient</code> when proposing a block.</p>
+<p>If no <code>--suggested-fee-recipient</code> is set neither on the validator client nor on the beacon node, the corresponding tips will be sent to the burn address, and forever lost,</p>
+
 :::tip Congratulations! 
 
-You’re now running a <strong>full Ethereum node</strong> and a <strong>validator</strong>.
+You’re now running a <strong>full Ethereum node</strong> and a <strong>validator client</strong>.
 
 :::
 

--- a/website/docs/monitoring/partials/_status-checklist-partial.md
+++ b/website/docs/monitoring/partials/_status-checklist-partial.md
@@ -136,11 +136,11 @@ import TabItem from '@theme/TabItem';
                 <Tabs className="tabgroup-with-label" groupId="network" defaultValue="mainnet" values={[
                         {label: 'Network:', value: 'label'},
                         {label: 'Mainnet', value: 'mainnet'},
-                        {label: 'Goerli-Prater', value: 'goerli-prater'},
+                        {label: 'Goerli', value: 'goerli'},
                         {label: 'Sepolia', value: 'sepolia'}
                     ]}>
                     <TabItem value="mainnet">Paste your validator's public key (available in your <code>deposit_data-*.json</code> file) into a <a href='https://beaconcha.in'>blockchain explorer like beaconcha.in</a> to check the status of your validator.</TabItem>
-                    <TabItem value="goerli-prater">Paste your validator's public key (available in your <code>deposit_data-*.json</code> file) into a <a href='https://prater.beaconcha.in/'>Goerli-Prater blockchain explorer like beaconcha.in</a> to check the status of your validator.</TabItem>
+                    <TabItem value="goerli">Paste your validator's public key (available in your <code>deposit_data-*.json</code> file) into a <a href='https://goerli.beaconcha.in/'>Goerli blockchain explorer like beaconcha.in</a> to check the status of your validator.</TabItem>
                     <TabItem value="sepolia">Running a validator on Sepolia is currently unsupported as Sepolia is a permissioned network, so there's nothing to do here.</TabItem>
                 </Tabs>
             </div>

--- a/website/docs/partials/_jwt-generation-partial.md
+++ b/website/docs/partials/_jwt-generation-partial.md
@@ -39,6 +39,15 @@ USE_PRYSM_VERSION=v4.0.0
 
 Prysm will output a `jwt.hex` file path.
 
+Move your `jwt.hex` file in your `ethereum` directory:
+
+```
+📂ethereum
+┣ 📂consensus
+┣ 📂execution
+┣ 📄jwt.hex
+```
+
 
 
 :::caution

--- a/website/docs/partials/_multidimensional-content-controls-partial.md
+++ b/website/docs/partials/_multidimensional-content-controls-partial.md
@@ -20,13 +20,13 @@ import {MultiDimensionalContentWidget} from '@site/src/components/MultiDimension
 <Tabs className="tabgroup-with-label network-tabgroup" groupId="network" defaultValue="mainnet" values={[
         {label: 'Network:', value: 'label'},
         {label: 'Mainnet', value: 'mainnet'},
-        {label: 'Goerli-Prater', value: 'goerli-prater'},
+        {label: 'Goerli', value: 'goerli'},
         {label: 'Sepolia', value: 'sepolia'},
         {label: 'Holesky', value: 'holesky'}
     ]}>
     <TabItem className="unclickable-element" value="label"></TabItem>
     <TabItem value="mainnet"></TabItem>
-    <TabItem value="goerli-prater"></TabItem>
+    <TabItem value="goerli"></TabItem>
     <TabItem value="sepolia"></TabItem>
     <TabItem value="holesky"></TabItem>
 </Tabs>

--- a/website/docs/prysm-usage/checkpoint-sync.md
+++ b/website/docs/prysm-usage/checkpoint-sync.md
@@ -110,7 +110,7 @@ The two exported `*.ssz` files are your `BeaconState` and `SignedBeaconBlock` fi
 curl -H "Accept: application/octet-stream"  http://localhost:3500/eth/v1/debug/beacon/states/genesis > genesis.ssz
 ```
 
-You can also just manually download the genesis state from GitHub: [Goerli-Prater](https://github.com/eth-clients/eth2-networks/raw/master/shared/prater/genesis.ssz) | [Sepolia](https://github.com/eth-clients/merge-testnets/blob/main/sepolia/genesis.ssz)
+You can also just manually download the genesis state from GitHub: [Goerli](https://github.com/eth-clients/eth2-networks/raw/master/shared/prater/genesis.ssz) | [Sepolia](https://github.com/eth-clients/merge-testnets/blob/main/sepolia/genesis.ssz)
 
 Use the following command to start your beacon node with checkpoint sync configured to use this checkpoint state:
 

--- a/website/docs/security-best-practices.md
+++ b/website/docs/security-best-practices.md
@@ -173,7 +173,7 @@ If you have any questions, feel free to visit our [Discord](https://discord.gg/p
 
 Footnotes:
 
-<strong id='footnote-1'>1</strong>. Learn more about the Goerli-Prater testnet <a href='https://goerli.launchpad.ethereum.org/en/'>here on Ethereum.org</a>. <br />
+<strong id='footnote-1'>1</strong>. Learn more about the Goerli testnet <a href='https://goerli.launchpad.ethereum.org/en/'>here on Ethereum.org</a>. <br />
 <strong id='footnote-2'>2</strong>. BitMex recently posted research that provides hard numbers on penalties and rewards: <a href='https://blog.bitmex.com/ethereums-proof-of-stake-system-calculating-penalties-rewards/'>Ethereum's Proof of Stake System - Calculating Penalties and Rewards</a>. Collin Myers has also created an <a href='https://docs.google.com/spreadsheets/d/15tmPOvOgi3wKxJw7KQJKoUe-uonbYR6HF7u83LR5Mj4/edit#gid=1018097491'>Ethereum calculator</a>. <br />
 <strong id='footnote-3'>3</strong>. See <a href='https://www.reddit.com/r/ethstaker/comments/nnwfx1/why_you_should_stop_worrying_about_your/'>Why you should stop worrying about your validator's uptime and start embracing the chaos instead</a>. <br />
 <strong id='footnote-4'>4</strong>. See <a href='https://medium.com/prysmatic-labs/eth2-slashing-prevention-tips-f6faa5025f50'>Eth2 Slashing Prevention Tips</a> to learn more about slashing.<br />

--- a/website/src/components/MultiDimensionalContentWidget.js
+++ b/website/src/components/MultiDimensionalContentWidget.js
@@ -73,8 +73,8 @@ export const MultiDimensionalContentWidget = () => {
 
 		if (isSelectedByText('Mainnet'))
 			selectedNetwork = "Mainnet";
-		else if (isSelectedByText('Goerli-Prater'))
-			selectedNetwork = "Goerli-Prater";
+		else if (isSelectedByText('Goerli'))
+			selectedNetwork = "Goerli";
 		else if (isSelectedByText('Sepolia'))
 			selectedNetwork = "Sepolia";
 		else if (isSelectedByText('Holesky'))


### PR DESCRIPTION
**Main changes:**
- Geth:
  - Remove the usage of the `Geth installer` as it seems not to be maintained any more. (Or at least I did not find it on Geth download page.)
  - Explicitly set the IPC file location, as the default location created by Geth does not match what the documentation currently use in the Prysm BN command line for MacOS.
- Nethermind:  
  - Explicitly set the IPC file location
  - Add win/others cases  
- Replace usage of `Goerli-Prater` by `Goerli` since even the EF https://prater.launchpad.ethereum.org/en/ redirects to  https://goerli.launchpad.ethereum.org/en/ without any mention of the word `prater`. (However, added a note to explained why the `genesis.ssz` file is still located under the `prater` directory.
- Add usage of `--suggested-fee-recipient` option in the Prysm VC command line.
- Reduce some "code" duplications by adding some Win/others or mainnet/testnets if/else cases where needed
- Fix some broken links
- Add some missing holesky/sepolia commands
- Add `--mainnet` flag everywhere on mainnet to be more explicit
- Add a link to the checkpoint sync page