### PR TITLE
V5 docs

### DIFF
--- a/website/docs/advanced/builder.md
+++ b/website/docs/advanced/builder.md
@@ -6,7 +6,7 @@ sidebar_label: Configure MEV Builder
 
 import {HeaderBadgesWidget} from '@site/src/components/HeaderBadgesWidget.js';
 
-<HeaderBadgesWidget commaDelimitedContributors="James" lastVerifiedDateString="May 18th, 2023" lastVerifiedVersionString="v4.0.2" />
+<HeaderBadgesWidget commaDelimitedContributors="James" lastVerifiedDateString="May 18th, 2023"/>
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';

--- a/website/docs/execution-node/fee-recipient-vNext.md
+++ b/website/docs/execution-node/fee-recipient-vNext.md
@@ -8,7 +8,7 @@ sidebar_label: Configure Fee Recipient (vNext)
 
 :::caution
 
-**This content has been upgraded to vCurrent as part of [Prysm v4.0.0](https://github.com/prysmaticlabs/prysm/releases)**.
+**This content has been upgraded to vCurrent as part of [Prysm releases](https://github.com/prysmaticlabs/prysm/releases)**.
 
 See [How to configure Fee Recipient](./fee-recipient.md) for the latest feature guidance.
 

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -117,7 +117,8 @@ Upgrading Prysm is done differently depending on your operating system and insta
 
 #### How can I downgrade Prysm to an older version?
 
-Upgrading Prysm is done differently depending on your operating system and installation method. Please note that downgrading may not be as easy as upgrading as some versions may not be backward compatible and you will need to perform extra steps. For example, migrating down from v1.x to v1.0.x has breaking changes that require you to also rollback your database.
+Upgrading Prysm is done differently depending on your operating system and installation method. Please note that downgrading may not be as easy as upgrading as some versions may not be backward compatible and you will need to perform extra steps. For example, migrating down from 
+<PrysmVersion minorOverride="1"/> to <PrysmVersion  minorOverride="0"/> has breaking changes that require you to also rollback your database. Downgrading major versions will not be possible.
 
 We prepared comprehensive instructions here in our docs portal on [upgrading and downgrading Prysm](/docs/prysm-usage/staying-up-to-date).
 

--- a/website/docs/partials/_jwt-generation-partial.md
+++ b/website/docs/partials/_jwt-generation-partial.md
@@ -1,5 +1,6 @@
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { PrysmVersion } from '@site/src/components/version.js';
 
 The HTTP connection between your beacon node and execution node needs to be authenticated using a [JWT token](https://jwt.io/). There are several ways to generate this JWT token:
 
@@ -15,24 +16,26 @@ The HTTP connection between your beacon node and execution node needs to be auth
   <TabItem className="unclickable-element" value="label"></TabItem>
   <TabItem value="win">
 
-```
-## Optional. This command is necessary only if you've previously configured USE_PRYSM_VERSION
-SET USE_PRYSM_VERSION=v4.0.0
+  <code>
 
-## Required.
-prysm.bat beacon-chain generate-auth-secret
-```
+  ## Optional. This command is necessary only if you've previously configured USE_PRYSM_VERSION
+  <span>SET USE_PRYSM_VERSION=<PrysmVersion/></span>
+
+  ## Required.
+  prysm.bat beacon-chain generate-auth-secret
+
+  </code>
   
   </TabItem>
   <TabItem value="others">
+  <code>
 
-```
-## Optional. This command is necessary only if you've previously configured USE_PRYSM_VERSION
-USE_PRYSM_VERSION=v4.0.0
+  ## Optional. This command is necessary only if you've previously configured USE_PRYSM_VERSION
+  <span>SET USE_PRYSM_VERSION=<PrysmVersion/></span>
 
-## Required.
-./prysm.sh beacon-chain generate-auth-secret
-```
+  ## Required.
+  ./prysm.sh beacon-chain generate-auth-secret
+  </code>
 
   </TabItem>
 </Tabs>

--- a/website/docs/prepare-for-merge.md
+++ b/website/docs/prepare-for-merge.md
@@ -9,6 +9,7 @@ import TabItem from '@theme/TabItem';
 import JwtGuidancePartial from '@site/docs/partials/_jwt-guidance-partial.md';
 
 import {HeaderBadgesWidget} from '@site/src/components/HeaderBadgesWidget.js';
+import { PrysmVersion } from '@site/src/components/version.js';
 
 <HeaderBadgesWidget commaDelimitedContributors="Raul,James" />
 
@@ -32,8 +33,8 @@ import MultidimensionalContentControlsPartial from '@site/docs/partials/_multidi
     <div className='task'>
         <div className='input-container'><input id="cl-1" type='checkbox'/><span className='done'></span></div>
         <div className='guidance-container'>
-            <label htmlFor="cl-1">Use Prysm v4.0.0</label>
-            <p>Prysm <a href='https://github.com/prysmaticlabs/prysm/releases/tag/v4.0.0'>v4.0.0</a> supports <strong>post-Merge</strong> configuration.</p>
+            <label htmlFor="cl-1">Use Prysm <PrysmVersion/></label>
+            <p>Prysm <PrysmVersion includeLink={true}/> supports <strong>post-Merge</strong> configuration.</p>
         </div>
     </div>
     <div className='task'>
@@ -47,7 +48,7 @@ import MultidimensionalContentControlsPartial from '@site/docs/partials/_multidi
         <div className='input-container'><input id="cl-6" type='checkbox'/><span className='done'></span></div>
         <div className='guidance-container'>
             <label htmlFor="cl-6">Verify your Prysm version</label>
-            <p>Verify that you're running Prysm <code>v4.0.0</code> by issuing the following command: <code>prysm.sh beacon-chain --version</code> (Linux) <code>prysm.bat beacon-chain --version</code> (Windows).</p>
+            <p>Verify that you're running Prysm <code><PrysmVersion/></code> by issuing the following command: <code>prysm.sh beacon-chain --version</code> (Linux) <code>prysm.bat beacon-chain --version</code> (Windows).</p>
         </div>
     </div>
     <div className='task'>

--- a/website/docs/prysm-usage/prysmctl.md
+++ b/website/docs/prysm-usage/prysmctl.md
@@ -51,6 +51,7 @@ Bazelisk is a launcher for Bazel which automatically downloads and installs the 
 
 - Using [a binary release](https://github.com/bazelbuild/bazelisk/releases) for Linux, macOS, or Windows
 - Using npm: `npm install -g @bazel/bazelisk`
+- Using apt: https://bazel.build/install/ubuntu
 - Using Homebrew on macOS: `brew install bazelisk`
 - By compiling from source using Go: `go install github.com/bazelbuild/bazelisk@latest`
 

--- a/website/docs/prysm-usage/staying-up-to-date.md
+++ b/website/docs/prysm-usage/staying-up-to-date.md
@@ -5,6 +5,8 @@ sidebar_label: Stay up to date
 ---
 
 import {HeaderBadgesWidget} from '@site/src/components/HeaderBadgesWidget.js';
+import { PrysmVersion } from '@site/src/components/version.js';
+
 
 <HeaderBadgesWidget />
 
@@ -20,8 +22,8 @@ There are three main ways of installing Prysm:
 
 ## Recommended versions
 
-Regardless of your installation method, we always recommend you are running the latest version in our [releases page](https://github.com/prysmaticlabs/prysm/releases) on Github, specified in [semver](https://semver.org/) format such as `v1.0.0-beta.1`. You can check your Prysm version by running your beacon node or validator with the `--version` flag. For example, if using `prysm.sh` to run the beacon node, you would run:
-f
+Regardless of your installation method, we always recommend you are running the latest version in our [releases page](https://github.com/prysmaticlabs/prysm/releases) on Github, specified in [semver](https://semver.org/) format such as <PrysmVersion/>. You can check your Prysm version by running your beacon node or validator with the `--version` flag. For example, if using `prysm.sh` to run the beacon node, you would run:
+
 ```
 ./prysm.sh beacon-chain --version
 ```
@@ -140,9 +142,9 @@ docker pull gcr.io/prysmaticlabs/prysm/validator:stable
 
 Sometimes, a new version might not work best for you and could impact your profitability negatively if there is an unforeseen issue in the software. To downgrade, there are a few important steps to keep in mind.
 
-### Downgrading between patch versions (v1.0.x)
+### Downgrading between patch versions
 
-If you are downgrading between **patch versions**, which means only the last number in the version changed, such as `v1.0.5` to `v1.0.4`, then follow the instructions below:
+If you are downgrading between **patch versions**, which means only the last number in the version changed, such as <PrysmVersion patchOverride="1"/> to <PrysmVersion />, then follow the instructions below:
 
 <Tabs
   groupId="operating-systems"
@@ -160,24 +162,24 @@ If you are downgrading between **patch versions**, which means only the last num
 
 If you are running `prysm.sh`, all it takes to downgrade to a previous release is to stop your beacon node and validator (wait for the process to close down gracefully). 
 
-Then, find the Prysm version you wish to run from our [releases page](https://github.com/prysmaticlabs/prysm/releases), such as v1.0.5, then run the command `export USE_PRYSM_VERSION=v1.0.5`.
+Then, find the Prysm version you wish to run from our [releases page](https://github.com/prysmaticlabs/prysm/releases),such as <PrysmVersion/> , then run the command <code>set USE_PRYSM_VERSION=<PrysmVersion/></code>.
 
 Then, restart it with the same command you used to start the process. The script will automatically use the release you specified.
 
 **Using Docker**
 
-To run a previous Prysm version with Docker, choose the release you want to run, then change all your docker run commands to use that version tag. For example, instead of `docker run gcr.io/prysmaticlabs/prysm:stable`, do `docker run gcr.io/prysmaticlabs/prysm:v1.0.5` if you want to run version v1.0.5.
+To run a previous Prysm version with Docker, choose the release you want to run, then change all your docker run commands to use that version tag. For example, instead of <code>docker run gcr.io/prysmaticlabs/prysm:stable</code>, do <code>docker run gcr.io/prysmaticlabs/prysm:<PrysmVersion/></code> if you want to run version <PrysmVersion/>.
 
 **Using Bazel**
 
-To run our latest release with Bazel, you can look up our [releases page](https://github.com/prysmaticlabs/prysm/releases), look at the release tag you want to run, such as v1.0.5, then do `git checkout v1.0.5`. Afterwards, you can re-run your beacon chain and validator as you ran them earlier with Bazel.
+To run our latest release with Bazel, you can look up our [releases page](https://github.com/prysmaticlabs/prysm/releases), look at the release tag you want to run, such as <PrysmVersion/>, then do <strong>git checkout <PrysmVersion/></strong> Afterwards, you can re-run your beacon chain and validator as you ran them earlier with Bazel.
 
 **Using Systemd**
   
-Edit the systemd files for both validator (`/etc/systemd/system/validator.service`) and beacon (`/etc/systemd/system/beacon.service`). The filename  depends on what you used when you installed, if you forgot the name, just `ls` that directory (`/etc/systemd/system/`) and edit them both. Add the `Environment` key under the `[Service]` group to have `Environment     =  USE_PRYSM_VERSION=v4.0.0`
+Edit the systemd files for both validator (`/etc/systemd/system/validator.service`) and beacon (`/etc/systemd/system/beacon.service`). The filename  depends on what you used when you installed, if you forgot the name, just `ls` that directory (`/etc/systemd/system/`) and edit them both. Add the `Environment` key under the `[Service]` group to have <code>Environment     =  USE_PRYSM_VERSION=<PrysmVersion/></code>
   
 Example for the beacon chain:
-```
+<code>
 [Unit]
 Description     = Ethereum Beacon Chain Service
 Wants           = network-online.target
@@ -189,11 +191,11 @@ User            = eth
 ExecStart       = /home/eth/prysm/prysm.sh beacon-chain --config-file=/etc/prysm/beacon-chain.yaml
 Restart         = on-failure
 TimeoutStopSec  = 900
-Environment     = USE_PRYSM_VERSION=v4.1.0
+Environment     = USE_PRYSM_VERSION=<PrysmVersion/>
 
 [Install]
 WantedBy    = multi-user.target
-```
+</code>
   
 After you finish editing both of the files, you need to reload the service unit
 ```
@@ -209,13 +211,13 @@ Once you do that, the prysm beacon and validator are locked in that version, so 
 
 If you are running `prysm.bat`, all it takes to downgrade to a previous release is to stop your beacon node and validator (wait for the process to close down gracefully). 
 
-Then, find the Prysm version you wish to run from our [releases page](https://github.com/prysmaticlabs/prysm/releases), such as v4.1.0, then run the command `set USE_PRYSM_VERSION=v4.1.0`.
+Then, find the Prysm version you wish to run from our [releases page](https://github.com/prysmaticlabs/prysm/releases), such as <PrysmVersion/> , then run the command <code>set USE_PRYSM_VERSION=<PrysmVersion/></code>.
 
 Then, restart it with the same command you used to start the process. The script will automatically use the release you specified.
 
 **Using Docker**
 
-To run a previous Prysm version with Docker, choose the release you want to run, then change all your docker run commands to use that version tag. For example, instead of `docker run gcr.io/prysmaticlabs/prysm:stable`, do `docker run gcr.io/prysmaticlabs/prysm:v4.1.0` if you want to run version v4.1.0.
+To run a previous Prysm version with Docker, choose the release you want to run, then change all your docker run commands to use that version tag. For example, instead of <code>docker run gcr.io/prysmaticlabs/prysm:stable</code>, do <code>docker run gcr.io/prysmaticlabs/prysm:<PrysmVersion/></code> if you want to run version <PrysmVersion/>.
 
 </TabItem>
 <TabItem value="mac">
@@ -224,17 +226,17 @@ To run a previous Prysm version with Docker, choose the release you want to run,
 
 If you are running `prysm.sh`, all it takes to downgrade to a previous release is to stop your beacon node and validator (wait for the process to close down gracefully). 
 
-Then, find the Prysm version you wish to run from our [releases page](https://github.com/prysmaticlabs/prysm/releases), such as v4.1.0, then run the command `export USE_PRYSM_VERSION=v4.1.0`.
+Then, find the Prysm version you wish to run from our [releases page](https://github.com/prysmaticlabs/prysm/releases), then run the command <code>export USE_PRYSM_VERSION=<PrysmVersion/></code>.
 
 Then, restart it with the same command you used to start the process. The script will automatically use the release you specified.
 
 **Using Docker**
 
-To run a previous Prysm version with Docker, choose the release you want to run, then change all your docker run commands to use that version tag. For example, instead of `docker run gcr.io/prysmaticlabs/prysm:stable`, do `docker run gcr.io/prysmaticlabs/prysm:v4.1.0` if you want to run version v4.1.0.
+To run a previous Prysm version with Docker, choose the release you want to run, then change all your docker run commands to use that version tag. For example, instead of <code>docker run gcr.io/prysmaticlabs/prysm:stable</code>, do <code>docker run gcr.io/prysmaticlabs/prysm:<PrysmVersion/></code> if you want to run version <PrysmVersion/>.
 
 **Using Bazel**
 
-To run our latest release with Bazel, you can look up our [releases page](https://github.com/prysmaticlabs/prysm/releases), look at the release tag you want to run, such as v4.1.0, then do `git checkout v4.1.0`. Afterwards, you can re-run your beacon chain and validator as you ran them earlier with Bazel.
+To run our latest release with Bazel, you can look up our [releases page](https://github.com/prysmaticlabs/prysm/releases), look at the release tag you want to run, such as <PrysmVersion/>, then do <code>git checkout <PrysmVersion/></code> Afterwards, you can re-run your beacon chain and validator as you ran them earlier with Bazel.
 
 </TabItem>
 <TabItem value="arm">
@@ -243,20 +245,20 @@ To run our latest release with Bazel, you can look up our [releases page](https:
 
 If you are running `prysm.sh`, all it takes to downgrade to a previous release is to stop your beacon node and validator (wait for the process to close down gracefully). 
 
-Then, find the Prysm version you wish to run from our [releases page](https://github.com/prysmaticlabs/prysm/releases), such as v4.1.0, then run the command `set=USE_PRYSM_VERSION=v4.1.0`.
+Then, find the Prysm version you wish to run from our [releases page](https://github.com/prysmaticlabs/prysm/releases), then run the command <code>export USE_PRYSM_VERSION=<PrysmVersion/></code>.
 
 Then, restart it with the same command you used to start the process. The script will automatically use the release you specified.
 
 **Using Docker**
 
-To run a previous Prysm version with Docker, choose the release you want to run, then change all your docker run commands to use that version tag. For example, instead of `docker run gcr.io/prysmaticlabs/prysm:stable`, do `docker run gcr.io/prysmaticlabs/prysm:v4.1.0` if you want to run version v4.1.0.
+To run a previous Prysm version with Docker, choose the release you want to run, then change all your docker run commands to use that version tag. For example, instead of <code>docker run gcr.io/prysmaticlabs/prysm:stable</code>, do <code>docker run gcr.io/prysmaticlabs/prysm:<PrysmVersion/></code> if you want to run version <PrysmVersion/>.
 
 </TabItem>
 </Tabs>
 
-### Downgrading between minor versions (v1.x)
+### Downgrading between minor versions
 
-If you are downgrading between **minor versions**, meaning the middle number in the version has changed, such as `v4.1.0` to `v4.1.x`, then follow the instructions below carefully:
+If you are downgrading between **minor versions**, meaning the middle number in the version has changed, such as <PrysmVersion minorOverride="1"/> to <PrysmVersion minorOverride="0"/>, then follow the instructions below carefully:
 
 Prerequisite: the validator.db will be needed in the steps below
 
@@ -292,13 +294,13 @@ Next up, run our database rollback command to make sure your database is going t
 prysm.sh validator db migrate down --datadir=/path/to/folder
 ```
 
-Then, find the Prysm version you wish to run from our [releases page](https://github.com/prysmaticlabs/prysm/releases), such as v4.1.0, then run the command `set=USE_PRYSM_VERSION=v4.1.0`.
+Then, find the Prysm version you wish to run from our [releases page](https://github.com/prysmaticlabs/prysm/releases).then run the command <code>export USE_PRYSM_VERSION=<PrysmVersion/></code>.
 
 Then, restart it with the same command you used to start the process. The script will automatically use the release you specified.
 
 **Using Docker**
 
-To run a previous Prysm version with Docker, choose the release you want to run, such as v1.0.5.
+To run a previous Prysm version with Docker, choose the release you want to run, such as <PrysmVersion/>.
 
 Next, we recommend backing up any important important folders such as your beacon node data directory and the validator wallet is important. You can simply make copies of the directories and keep them safe in case the downgrade process goes wrong. 
 
@@ -308,11 +310,12 @@ Next up, run our database rollback command to make sure your database is going t
 docker run -v /path/to/folder:/data gcr.io/prysmaticlabs/prysm/validator:stable db migrate down --datadir=/data
 ```
 
-Then change all your docker run commands to use that version tag. For example, instead of `docker run gcr.io/prysmaticlabs/prysm:stable`, do `docker run gcr.io/prysmaticlabs/prysm:v4.1.0` if you want to run version v4.1.0.
+Then change all your docker run commands to use that version tag. For example, instead of <code>docker run gcr.io/prysmaticlabs/prysm:stable</code>, do <code>docker run gcr.io/prysmaticlabs/prysm:<PrysmVersion/></code> if you want to run version <PrysmVersion/>.
+
 
 **Using Bazel**
 
-To run our latest release with Bazel, you can look up our [releases page](https://github.com/prysmaticlabs/prysm/releases), look at the release tag you want to run, such as v4.1.0.
+To run our latest release with Bazel, you can look up our [releases page](https://github.com/prysmaticlabs/prysm/releases), look at the release tag you want to run, such as <PrysmVersion/>.
 
 Next, we recommend backing up any important important folders such as your beacon node data directory and the validator wallet is important. You can simply make copies of the directories and keep them safe in case the downgrade process goes wrong. 
 
@@ -322,7 +325,7 @@ Next up, run our database rollback command to make sure your database is going t
 bazel run //cmd/validator:validator -- db migrate down --datadir=/path/to/folder
 ```
 
-Then do `git checkout v4.1.0`. Afterwards, you can re-run your beacon chain and validator as you ran them earlier with Bazel.
+Then do <strong>git checkout <PrysmVersion/></strong> Afterwards, you can re-run your beacon chain and validator as you ran them earlier with Bazel.
 
 </TabItem>
 <TabItem value="win">
@@ -339,9 +342,9 @@ Next up, run our database rollback command to make sure your database is going t
 prysm.bat validator db migrate down --datadir=\path\to\folder
 ```
 
-Then, find the Prysm version you wish to run from our [releases page](https://github.com/prysmaticlabs/prysm/releases), such as v4.1.0, then run the command `set USE_PRYSM_VERSION=v4.1.0`.
+Then, find the Prysm version you wish to run from our [releases page](https://github.com/prysmaticlabs/prysm/releases), such as <PrysmVersion/> , then run the command <code>set USE_PRYSM_VERSION=<PrysmVersion/></code>.
 
-:::warn
+:::warning
 
 In Windows, there isn't a native DOS command that directly sets a global environment variable permanently from the command line. The set command in Windows Command Prompt (CMD) only sets environment variables for the current session.
 To permanently set this you will need up update your environment variables in the control panel.
@@ -354,7 +357,7 @@ Then, restart it with the same command you used to start the process. The script
 
 **Using Docker**
 
-To run a previous Prysm version with Docker, choose the release you want to run, such as v4.1.0.
+To run a previous Prysm version with Docker, choose the release you want to run, such as <PrysmVersion/>.
 
 Next, we recommend backing up any important important folders such as your beacon node data directory and the validator wallet is important. You can simply make copies of the directories and keep them safe in case the downgrade process goes wrong. 
 
@@ -364,7 +367,7 @@ Next up, run our database rollback command to make sure your database is going t
 docker run -v \path\to\folder:/data gcr.io/prysmaticlabs/prysm/validator:stable db migrate down --datadir=/data
 ```
 
-Then change all your docker run commands to use that version tag. For example, instead of `docker run gcr.io/prysmaticlabs/prysm:stable`, do `docker run gcr.io/prysmaticlabs/prysm:v4.1.0` if you want to run version v4.1.0.
+Then change all your docker run commands to use that version tag. For example, instead of <code>docker run gcr.io/prysmaticlabs/prysm:stable</code>, do <code>docker run gcr.io/prysmaticlabs/prysm:<PrysmVersion/></code> if you want to run version <PrysmVersion/>.
 
 </TabItem>
 <TabItem value="mac">
@@ -381,13 +384,13 @@ Next up, run our database rollback command to make sure your database is going t
 prysm.sh validator db migrate down --datadir=/path/to/folder
 ```
 
-Then, find the Prysm version you wish to run from our [releases page](https://github.com/prysmaticlabs/prysm/releases), such as v4.1.0, then run the command `export USE_PRYSM_VERSION=v4.1.0`.
+Then, find the Prysm version you wish to run from our [releases page](https://github.com/prysmaticlabs/prysm/releases), such as <PrysmVersion/> , then run the command <code>set USE_PRYSM_VERSION=<PrysmVersion/></code>.
 
 Then, restart it with the same command you used to start the process. The script will automatically use the release you specified.
 
 **Using Docker**
 
-To run a previous Prysm version with Docker, choose the release you want to run, such as v4.1.0.
+To run a previous Prysm version with Docker, choose the release you want to run, such as <PrysmVersion/>.
 
 Next, we recommend backing up any important important folders such as your beacon node data directory and the validator wallet is important. You can simply make copies of the directories and keep them safe in case the downgrade process goes wrong. 
 
@@ -397,11 +400,11 @@ Next up, run our database rollback command to make sure your database is going t
 docker run -v /path/to/folder:/data gcr.io/prysmaticlabs/prysm/validator:stable db migrate down --datadir=/data
 ```
 
-Then change all your docker run commands to use that version tag. For example, instead of `docker run gcr.io/prysmaticlabs/prysm:stable`, do `docker run gcr.io/prysmaticlabs/prysm:v4.1.0` if you want to run version v4.1.0.
+Then change all your docker run commands to use that version tag. For example, instead of <code>docker run gcr.io/prysmaticlabs/prysm:stable</code>, do <code>docker run gcr.io/prysmaticlabs/prysm:<PrysmVersion/></code> if you want to run version <PrysmVersion/>.
 
 **Using Bazel**
 
-To run our latest release with Bazel, you can look up our [releases page](https://github.com/prysmaticlabs/prysm/releases), look at the release tag you want to run, such as v4.1.0.
+To run our latest release with Bazel, you can look up our [releases page](https://github.com/prysmaticlabs/prysm/releases), look at the release tag you want to run, such as <PrysmVersion/>.
 
 Next, we recommend backing up any important important folders such as your beacon node data directory and the validator wallet is important. You can simply make copies of the directories and keep them safe in case the downgrade process goes wrong. 
 
@@ -411,7 +414,7 @@ Next up, run our database rollback command to make sure your database is going t
 bazel run //cmd/validator:validator -- db migrate down --datadir=/path/to/folder
 ```
 
-Then do `git checkout v4.1.0`. Afterwards, you can re-run your beacon chain and validator as you ran them earlier with Bazel.
+Then do <strong>git checkout <PrysmVersion/></strong> Afterwards, you can re-run your beacon chain and validator as you ran them earlier with Bazel.
 
 </TabItem>
 <TabItem value="arm">
@@ -428,13 +431,13 @@ Next up, run our database rollback command to make sure your database is going t
 prysm.sh validator db migrate down --datadir=/path/to/folder
 ```
 
-Then, find the Prysm version you wish to run from our [releases page](https://github.com/prysmaticlabs/prysm/releases), such as v4.1.0, then run the command `set=USE_PRYSM_VERSION=v4.1.0`.
+Then, find the Prysm version you wish to run from our [releases page](https://github.com/prysmaticlabs/prysm/releases), such as <PrysmVersion/> , then run the command <code>set USE_PRYSM_VERSION=<PrysmVersion/></code>.
 
 Then, restart it with the same command you used to start the process. The script will automatically use the release you specified.
 
 **Using Docker**
 
-To run a previous Prysm version with Docker, choose the release you want to run, such as v1.0.5.
+To run a previous Prysm version with Docker, choose the release you want to run, such as <PrysmVersion/>.
 
 Next, we recommend backing up any important important folders such as your beacon node data directory and the validator wallet is important. You can simply make copies of the directories and keep them safe in case the downgrade process goes wrong. 
 
@@ -444,13 +447,13 @@ Next up, run our database rollback command to make sure your database is going t
 docker run -v /path/to/folder:/data gcr.io/prysmaticlabs/prysm/validator:stable db migrate down --datadir=/data
 ```
 
-Then change all your docker run commands to use that version tag. For example, instead of `docker run gcr.io/prysmaticlabs/prysm:stable`, do `docker run gcr.io/prysmaticlabs/prysm:v4.1.0` if you want to run version v4.1.0.
+Then change all your docker run commands to use that version tag. For example, instead of <code>docker run gcr.io/prysmaticlabs/prysm:stable</code>, do <code>docker run gcr.io/prysmaticlabs/prysm:<PrysmVersion/></code> if you want to run version <PrysmVersion/>.
 
 </TabItem>
 </Tabs>
 
 ### Downgrading between major version bumps
 
-For **major version bumps** such as from `v3.0.0` to `v4.0.0`, you cannot downgrade as these are meant to be backwards incompatible changes.
+For **major version bumps** such as from <PrysmVersion/> to <PrysmVersion majorOverride="4"/>, you cannot downgrade as these are meant to be backwards incompatible changes.
 
 

--- a/website/docs/wallet/deterministic.md
+++ b/website/docs/wallet/deterministic.md
@@ -87,38 +87,14 @@ Where you'll see the following output
 INFO accounts: (wallet path) /Users/johndoe/Library/Eth2Validators/prysm-wallet-v2
 
 Showing **1** validator account
-View the eth1 deposit transaction data for your accounts by running `validator accounts list --show-deposit-data
+View the eth1 deposit transaction data for your accounts by running `validator accounts list
 
 personally-conscious-echidna
-[withdrawal public key] 0xa9c19b160cdc5c6dd74bf5a528d53b9a196ab8dda550e7e5858d84bf356952a310b826e269b9b462293f1c2812263161
 [validating public key] 0x971d780edfe98743f41cdcdba8521548fc343ffcd958e90968c4f1cc5a2e9b6ea11a984397c34c6cc13e9d4e8d14ce1e
 [created at] 16 minutes ago
 ```
 
-You can view the `deposit_data` needed to send 32ETH to the Ethereum validator deposit contract for your validator accounts by optionally passing in a `--show-deposit-data` flag as follows.
-
-```bash
-./prysm.sh validator accounts list --show-deposit-data
-```
-
-Where you'll see the following output
-
-```bash
-INFO accounts: (wallet path) /Users/johndoe/Library/Eth2Validators/prysm-wallet-v2
-
-Showing **1** validator account
-
-personally-conscious-echidna
-[withdrawal public key] 0xa9c19b160cdc5c6dd74bf5a528d53b9a196ab8dda550e7e5858d84bf356952a310b826e269b9b462293f1c2812263161
-[validating public key] 0x971d780edfe98743f41cdcdba8521548fc343ffcd958e90968c4f1cc5a2e9b6ea11a984397c34c6cc13e9d4e8d14ce1e
-[created at] 16 minutes ago
-
-========================Deposit Data===============================
-
-0x2289511800000000000000000000000000000000000000000...
-
-===================================================================
-```
+You can view the `deposit_data` needed to send 32ETH to the Ethereum validator deposit contract 
 
 You can also run the `accounts list` command **non-interactively** by using the following command line flags, which are also viewable by typing `./prysm.sh validator accounts list --help`.
 
@@ -126,7 +102,6 @@ You can also run the `accounts list` command **non-interactively** by using the 
 | ------------------------ | :---------------------------------------------------------------------------- |
 | `--wallet-dir`           | Path to a wallet directory (default: "$HOME/Eth2Validators/prysm-wallet-v2"). |
 | `--wallet-password-file` | Path to plain-text file containing your wallet's password.                    |
-| `--show-deposit-data`    | Display raw eth1 tx deposit data for validator accounts.                      |
 | `--show-private-keys`    | Display the private keys for validator accounts.                              |
 
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -1,3 +1,5 @@
+var prysmVersion = "v5.0.0";
+
 module.exports = {
     title: 'Prysm',
     tagline: 'Ethereum consensus implementation written entirely in Go.',
@@ -11,6 +13,7 @@ module.exports = {
 
     customFields: {
         image: 'img/Prysm.svg',
+        prysmVersion: prysmVersion,
     },
     trailingSlash: false,
     scripts: ['https://buttons.github.io/buttons.js'],
@@ -26,8 +29,8 @@ module.exports = {
             items: [{
                 type: 'docsVersion',
                 position: 'left',
-                to: 'https://github.com/prysmaticlabs/prysm/releases/tag/v4.0.0',
-                label: 'v4.0.0',
+                to: 'https://github.com/prysmaticlabs/prysm/releases/tag/'+prysmVersion,
+                label: prysmVersion,
             },
             {
                 to: 'docs/install/install-with-script',

--- a/website/src/components/version.js
+++ b/website/src/components/version.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+
+export const PrysmVersion = ({ includeLink = false, majorOverride = null, minorOverride = null, patchOverride = null}) => {
+  const { siteConfig } = useDocusaurusContext();
+  const versionString = siteConfig?.customFields?.prysmVersion;
+
+  // Split the version string into parts
+  let [major, minor, patch] = versionString.split('.');
+
+  if (majorOverride !== null && !isNaN(majorOverride)) {
+    major = majorOverride;
+  }
+  // Override the minor version if minorOverride is provided
+  if (minorOverride !== null && !isNaN(minorOverride)) {
+    minor = minorOverride;
+  }
+  if (patchOverride !== null && !isNaN(patchOverride)) {
+    patch = patchOverride;
+  }
+  // Reconstruct the version string with the potential minor version override
+  const version = `${major}.${minor}.${patch}`;
+  const currentVersionLink = `https://github.com/prysmaticlabs/prysm/releases/tag/${version}`;
+
+  return includeLink ? (
+    <span><a href={currentVersionLink} target="_blank" rel="noopener noreferrer">{version}</a></span>
+  ) : (
+    <span>{version}</span>
+  );
+};
+


### PR DESCRIPTION
updates the prysm version to V5 and introduces a custom component to easily update the version in the docs code base.

also fixes https://github.com/prysmaticlabs/documentation/issues/914,https://github.com/prysmaticlabs/documentation/issues/911
