### PR TITLE
grpc gateway deprecated, update flags in doc

### DIFF
--- a/website/docs/advanced/proof-of-stake-devnet.md
+++ b/website/docs/advanced/proof-of-stake-devnet.md
@@ -513,7 +513,7 @@ Run a second go-ethereum node as follows:
 
 Then, run a second Prysm beacon node as follows:
 
-    ./beacon-chain --datadir beacondata2 --min-sync-peers 1 --genesis-state genesis.ssz --bootstrap-node= --interop-eth1data-votes --chain-config-file config.yml --contract-deployment-block 0 --chain-id 32382 --accept-terms-of-use --jwt-secret jwt.hex --suggested-fee-recipient 0x123463a4B065722E99115D6c222f267d9cABb524 --minimum-peers-per-subnet 0 --enable-debug-rpc-endpoints --execution-endpoint gethdata2/geth.ipc --peer=$PEER --p2p-udp-port 12001 --p2p-tcp-port 13001 --grpc-gateway-port 3501 --rpc-port 4001
+    ./beacon-chain --datadir beacondata2 --min-sync-peers 1 --genesis-state genesis.ssz --bootstrap-node= --interop-eth1data-votes --chain-config-file config.yml --contract-deployment-block 0 --chain-id 32382 --accept-terms-of-use --jwt-secret jwt.hex --suggested-fee-recipient 0x123463a4B065722E99115D6c222f267d9cABb524 --minimum-peers-per-subnet 0 --enable-debug-rpc-endpoints --execution-endpoint gethdata2/geth.ipc --peer=$PEER --p2p-udp-port 12001 --p2p-tcp-port 13001 --http-port 3501 --rpc-port 4001
     
 
 You will see the node start to synchronize with the chain as expected!

--- a/website/docs/how-prysm-works/ethereum-public-api.md
+++ b/website/docs/how-prysm-works/ethereum-public-api.md
@@ -21,7 +21,13 @@ As of the time of writing, there are three definitions: [v1](https://ethereum.gi
 The API's purpose is a means of communication between your beacon node and your validator client. Because of this it is not protected against external malicious users. Some endpoints are vulnerable to Denial-of-Service attacks, while others may disclose information about your beacon node. The communication between the beacon node and the validator client should be done privately, either on the same machine or through an SSH connection.
 :::
 
-The API is exposed by default on `127.0.0.1:3500`. The host can be changed by manipulating the `--grpc-gateway-host` flag and the port can be modified with the `--grpc-gateway-port` flag. Performing a request is straightforward - simply concatenate the host with the port and the API's URL, providing any required URL and query parameters. As an example, the finalized state's root can be obtained using:
+:::caution
+`http-host` and `http-port` have replaced `--grpc-gateway-host` and `--grpc-gateway-port` respectively.
+:::
+
+The API is exposed by default on `127.0.0.1:3500`. The host can be changed by manipulating the `--http-host` flag and the port can be modified with the `--http-port` flag. 
+
+Performing a request is straightforward - simply concatenate the host with the port and the API's URL, providing any required URL and query parameters. As an example, the finalized state's root can be obtained using:
 ```
 http://127.0.0.1:3500/eth/v1/beacon/states/finalized/root
 ```

--- a/website/docs/how-prysm-works/prysm-public-api.md
+++ b/website/docs/how-prysm-works/prysm-public-api.md
@@ -37,7 +37,7 @@ By default the beacon node runs with all available set of APIs enabled. You migh
 
 ## RESTful endpoints \(gRPC Transcoding\)
 
-All of the gRPC services should define JSON over HTTP endpoints by specifying [HTTPRules](https://github.com/googleapis/googleapis/blob/master/google/api/http.proto). Developers may choose to bundle a REST service of gRPC with their client implementation binaries, or alternatively, they may use a JSON encoding proxy such as [Envoy Proxy](https://www.envoyproxy.io/), [grpc-gateway](https://github.com/grpc-ecosystem/grpc-gateway), etc.
+All of the gRPC services should define JSON over HTTP endpoints by specifying [HTTPRules](https://github.com/googleapis/googleapis/blob/master/google/api/http.proto). Developers may choose to bundle a REST service of gRPC with their client implementation binaries, or alternatively, they may use a JSON encoding proxy such as [Envoy Proxy](https://www.envoyproxy.io/), etc.
 
 For more information on gRPC transcoding, see the examples found [here](https://github.com/googleapis/googleapis/blob/master/google/api/http.proto#L45).
 

--- a/website/docs/install/install-with-docker.md
+++ b/website/docs/install/install-with-docker.md
@@ -127,7 +127,7 @@ docker run -it -v $HOME/.eth2:/data -p 4000:4000 -p 13000:13000 -p 12000:12000/u
   --datadir=/data \
   --jwt-secret=<YOUR_JWT_SECRET> \
   --rpc-host=0.0.0.0 \
-  --grpc-gateway-host=0.0.0.0 \
+  --http-host=0.0.0.0 \
   --monitoring-host=0.0.0.0 \
   --execution-endpoint=<YOUR_ETH_EXECUTION_NODE_ENDPOINT>
 ```
@@ -143,7 +143,7 @@ docker run -it -v $HOME/.eth2:/data -v /path/to/genesis.ssz:/genesis/genesis.ssz
   --datadir=/data \
   --jwt-secret=<YOUR_JWT_SECRET> \
   --rpc-host=0.0.0.0 \
-  --grpc-gateway-host=0.0.0.0 \
+  --http-host=0.0.0.0 \
   --monitoring-host=0.0.0.0 \
   --execution-endpoint=<YOUR_ETH_EXECUTION_NODE_ENDPOINT> \
   --genesis-state=/genesis/genesis.ssz \
@@ -161,7 +161,7 @@ docker run -it -v $HOME/.eth2:/data -v /path/to/genesis.ssz:/genesis/genesis.ssz
   --datadir=/data \
   --jwt-secret=<YOUR_JWT_SECRET> \
   --rpc-host=0.0.0.0 \
-  --grpc-gateway-host=0.0.0.0 \
+  --http-host=0.0.0.0 \
   --monitoring-host=0.0.0.0 \
   --execution-endpoint=<YOUR_ETH_EXECUTION_NODE_ENDPOINT> \
   --genesis-state=/genesis/genesis.ssz \
@@ -187,7 +187,7 @@ To ensure that your Docker image has access to a data directory, mount a local d
       <TabItem value="mainnet">
 
 ```text
-docker run -it -v %LOCALAPPDATA%\Eth2:/data -p 4000:4000 -p 13000:13000 -p 12000:12000/udp gcr.io/prysmaticlabs/prysm/beacon-chain:stable --datadir=/data --jwt-secret=<YOUR_JWT_SECRET> --rpc-host=0.0.0.0 --grpc-gateway-host=0.0.0.0 --monitoring-host=0.0.0.0 --execution-endpoint=<YOUR_ETH_EXECUTION_NODE_ENDPOINT> 
+docker run -it -v %LOCALAPPDATA%\Eth2:/data -p 4000:4000 -p 13000:13000 -p 12000:12000/udp gcr.io/prysmaticlabs/prysm/beacon-chain:stable --datadir=/data --jwt-secret=<YOUR_JWT_SECRET> --rpc-host=0.0.0.0 --http-host=0.0.0.0 --monitoring-host=0.0.0.0 --execution-endpoint=<YOUR_ETH_EXECUTION_NODE_ENDPOINT> 
 ```
 
   </TabItem>
@@ -196,7 +196,7 @@ docker run -it -v %LOCALAPPDATA%\Eth2:/data -p 4000:4000 -p 13000:13000 -p 12000
 Download the Sepolia genesis state from [Github](https://github.com/eth-clients/sepolia/blob/main/bepolia/genesis.ss) to a local file, then run:
 
 ```text
-docker run -it -v %LOCALAPPDATA%\Eth2:/data -v \path\to\genesis.ssz:/genesis/genesis.ssz -p 4000:4000 -p 13000:13000 -p 12000:12000/udp gcr.io/prysmaticlabs/prysm/beacon-chain@sha256:bf9b95661c71ad60f633ee14cf352a668d550076471154cf80dfef8fce0bb41e --datadir=/data --jwt-secret=<YOUR_JWT_SECRET> --rpc-host=0.0.0.0 --grpc-gateway-host=0.0.0.0 --monitoring-host=0.0.0.0 --execution-endpoint=<YOUR_ETH_EXECUTION_NODE_ENDPOINT> --genesis-state=/genesis/genesis.ssz --sepolia
+docker run -it -v %LOCALAPPDATA%\Eth2:/data -v \path\to\genesis.ssz:/genesis/genesis.ssz -p 4000:4000 -p 13000:13000 -p 12000:12000/udp gcr.io/prysmaticlabs/prysm/beacon-chain@sha256:bf9b95661c71ad60f633ee14cf352a668d550076471154cf80dfef8fce0bb41e --datadir=/data --jwt-secret=<YOUR_JWT_SECRET> --rpc-host=0.0.0.0 --http-host=0.0.0.0 --monitoring-host=0.0.0.0 --execution-endpoint=<YOUR_ETH_EXECUTION_NODE_ENDPOINT> --genesis-state=/genesis/genesis.ssz --sepolia
 ```
 
   </TabItem>
@@ -205,7 +205,7 @@ docker run -it -v %LOCALAPPDATA%\Eth2:/data -v \path\to\genesis.ssz:/genesis/gen
 Download the Holesky genesis state from [Github](https://github.com/eth-clients/holesky/blob/main/custom_config_data/genesis.ssz) to a local file, then run:
 
 ```text
-docker run -it -v %LOCALAPPDATA%\Eth2:/data -v \path\to\genesis.ssz:/genesis/genesis.ssz -p 4000:4000 -p 13000:13000 -p 12000:12000/udp gcr.io/prysmaticlabs/prysm/beacon-chain@sha256:bf9b95661c71ad60f633ee14cf352a668d550076471154cf80dfef8fce0bb41e --datadir=/data --jwt-secret=<YOUR_JWT_SECRET> --rpc-host=0.0.0.0 --grpc-gateway-host=0.0.0.0 --monitoring-host=0.0.0.0 --execution-endpoint=<YOUR_ETH_EXECUTION_NODE_ENDPOINT> --genesis-state=/genesis/genesis.ssz --holesky
+docker run -it -v %LOCALAPPDATA%\Eth2:/data -v \path\to\genesis.ssz:/genesis/genesis.ssz -p 4000:4000 -p 13000:13000 -p 12000:12000/udp gcr.io/prysmaticlabs/prysm/beacon-chain@sha256:bf9b95661c71ad60f633ee14cf352a668d550076471154cf80dfef8fce0bb41e --datadir=/data --jwt-secret=<YOUR_JWT_SECRET> --rpc-host=0.0.0.0 --http-host=0.0.0.0 --monitoring-host=0.0.0.0 --execution-endpoint=<YOUR_ETH_EXECUTION_NODE_ENDPOINT> --genesis-state=/genesis/genesis.ssz --holesky
 ```
 
   </TabItem>
@@ -387,7 +387,10 @@ docker run -it -v %LOCALAPPDATA%\Eth2:/data -p 4000:4000 -p 13000:13000 -p 12000
 
 ## Frequently asked questions
 
-**Why do we set `--rpc-host` and `--grpc-gateway-host` to `0.0.0.0`?** <br />
+**Why do we set `--rpc-host` and `--http-host` to `0.0.0.0`?** <br />
+:::info
+`http-host` and `http-port` have replaced `--grpc-gateway-host` and `--grpc-gateway-port` respectively.
+:::
 This tells your Docker container to to "listen" for connections from outside of your container, allowing you (and other services) to reach your RPC endpoint(s). See [Configure ports and firewalls](../prysm-usage/p2p-host-ip.md) for more information.
 
 

--- a/website/docs/prysm-usage/web-interface.md
+++ b/website/docs/prysm-usage/web-interface.md
@@ -101,15 +101,19 @@ upon completion of onboarding, your web page should always redirect you to the m
 The web UI runs by default on port 7500 of the validator client if you are running with the `--web` flag. To customize this port, change the following flag to your liking:
 
 ```
---grpc-gateway-port (default: 7500 for validator)
+--http-port (default: 7500 for validator)
 ```
 
 The available parameters to customize are:
 
 | Flag                  | Usage                                                                  |
 | --------------------- | :--------------------------------------------------------------------- |
-| `--grpc-gateway-host` | The host for the validator client's JSON-HTTP API, default `127.0.0.1` |
-| `--grpc-gateway-port` | The port for the validator client's JSON-HTTP API, default `7500`      |
+| `--http-host` | The host for the validator client's JSON-HTTP API, default `127.0.0.1` |
+| `--http-port` | The port for the validator client's JSON-HTTP API, default `7500`      |
+
+:::caution
+`http-host` and `http-port` have replaced `--grpc-gateway-host` and `--grpc-gateway-port` respectively.
+:::
 
 ### Wallet Directory
 


### PR DESCRIPTION
grpc gateway will be deprecated in the next release, flag names are updated in docs, old alias can still be used. 

related to https://github.com/prysmaticlabs/prysm/pull/14089