### PR TITLE
monitoring: updating docs to use standard apis

### DIFF
--- a/website/docs/install/install-with-docker.md
+++ b/website/docs/install/install-with-docker.md
@@ -235,7 +235,7 @@ import FullSyncWarningPartial from '@site/docs/partials/_full-sync-warning-parti
 Check the sync status of your node with the following command:
 
 ```text
-curl http://localhost:3500/eth/v1alpha1/node/syncing
+curl http://localhost:3500/eth/v1/node/syncing
 ```
 
 If your node is done synchronizing, you will see the response:

--- a/website/docs/monitoring/partials/_status-checklist-partial.md
+++ b/website/docs/monitoring/partials/_status-checklist-partial.md
@@ -120,8 +120,7 @@ import TabItem from '@theme/TabItem';
             <div className='guidance-container'>
                 <label htmlFor="st-7">9. Beacon node ↔ execution node connectivity</label>
                 <p>Issue <code>curl http://localhost:3500/eth/v1/node/syncing</code> from a separate terminal window. 
-                `"el_offline": false` in the response can be interpreted as "EN-BN connection is healthy". Otherwise, observing the fields `"is_optimistic":true` may indicate that the execution node is still syncing or may have other issues. 
-                more details on this endpoint found on <a href='https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Node/getSyncingStatus'> the beacon API site </a>
+                `"el_offline": false` in the response can be interpreted as "EN-BN connection is healthy". Otherwise, observing the fields `"is_optimistic":true` may indicate that the execution node is still syncing or may have other issues. more details on this endpoint found on <a href='https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Node/getSyncingStatus'>the beacon API site</a>
             </div>
         </div>
         <div className='task'>

--- a/website/docs/monitoring/partials/_status-checklist-partial.md
+++ b/website/docs/monitoring/partials/_status-checklist-partial.md
@@ -120,7 +120,7 @@ import TabItem from '@theme/TabItem';
             <div className='guidance-container'>
                 <label htmlFor="st-7">9. Beacon node ↔ execution node connectivity</label>
                 <p>Issue <code>curl http://localhost:3500/eth/v1/node/syncing</code> from a separate terminal window. 
-                `"el_offline": false` in the response can be interpreted as "EN-BN connection is healthy". Otherwise, observing the fields `"is_optimistic":true` may indicate that the execution node is still syncing or may have other issues. more details on this endpoint found on <a href='https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Node/getSyncingStatus'>the beacon API site</a>
+                `"el_offline": false` in the response can be interpreted as "EN-BN connection is healthy". Otherwise, observing the fields `"is_optimistic":true` may indicate that the execution node is still syncing or may have other issues. more details on this endpoint found on <a href='https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Node/getSyncingStatus'>the beacon API site</a></p>
             </div>
         </div>
         <div className='task'>

--- a/website/docs/monitoring/partials/_status-checklist-partial.md
+++ b/website/docs/monitoring/partials/_status-checklist-partial.md
@@ -120,7 +120,7 @@ import TabItem from '@theme/TabItem';
             <div className='guidance-container'>
                 <label htmlFor="st-7">9. Beacon node ↔ execution node connectivity</label>
                 <p>Issue <code>curl http://localhost:3500/eth/v1/node/syncing</code> from a separate terminal window. 
-                `"el_offline": false` in the response can be interpreted as "EN-BN connection is healthy". Otherwise, the observing the fields `"is_syncing":true` or `"is_optimistic":true` may indicate that the execution node is still syncing or may have other issues. 
+                `"el_offline": false` in the response can be interpreted as "EN-BN connection is healthy". Otherwise, observing the fields `"is_optimistic":true` may indicate that the execution node is still syncing or may have other issues. 
                 more details on this endpoint found on <a href='https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Node/getSyncingStatus'> the beacon API site </a>
             </div>
         </div>

--- a/website/docs/monitoring/partials/_status-checklist-partial.md
+++ b/website/docs/monitoring/partials/_status-checklist-partial.md
@@ -119,7 +119,9 @@ import TabItem from '@theme/TabItem';
             <div className='input-container'><input id="st-7" type='checkbox'/><span className='done'></span></div>
             <div className='guidance-container'>
                 <label htmlFor="st-7">9. Beacon node ↔ execution node connectivity</label>
-                <p>Issue <code>curl http://localhost:3500/eth/v1alpha1/node/eth1/connections</code> from a separate terminal window. If you see <code>currentConnectionError: no contract code at given address</code>, your execution node may still be syncing. Otherwise, if you don't see any errors, your beacon node is connected to your execution node. This output can be interpreted as "EN-BN connection is healthy": <code>&#123;"currentAddress":"http://localhost:8551","currentConnectionError":"","addresses":["http://localhost:8551"],"connectionErrors":[]&#125;</code></p>
+                <p>Issue <code>curl http://localhost:3500/eth/v1/node/syncing</code> from a separate terminal window. 
+                `"el_offline": false` in the response can be interpreted as "EN-BN connection is healthy". Otherwise, the observing the fields `"is_syncing":true` or `"is_optimistic":true` may indicate that the execution node is still syncing or may have other issues. 
+                more details on this endpoint found on <a href='https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Node/getSyncingStatus'> the beacon API site </a>
             </div>
         </div>
         <div className='task'>

--- a/website/docs/monitoring/partials/_status-checklist-partial.md
+++ b/website/docs/monitoring/partials/_status-checklist-partial.md
@@ -119,8 +119,8 @@ import TabItem from '@theme/TabItem';
             <div className='input-container'><input id="st-7" type='checkbox'/><span className='done'></span></div>
             <div className='guidance-container'>
                 <label htmlFor="st-7">9. Beacon node ↔ execution node connectivity</label>
-                <p>Issue <code>curl http://localhost:3500/eth/v1/node/syncing</code> from a separate terminal window. 
-                `"el_offline": false` in the response can be interpreted as "EN-BN connection is healthy". Otherwise, observing the fields `"is_optimistic":true` may indicate that the execution node is still syncing or may have other issues. more details on this endpoint found on <a href='https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Node/getSyncingStatus'>the beacon API site</a></p>
+                <p>In a separate terminal window, run <code>curl http://localhost:3500/eth/v1/node/syncing</code>. 
+                If the response shows `"el_offline": false`, it can be interpreted as the "EN-BN connection is healthy". However, if you see `"is_optimistic": true`, it may indicate that the execution node is still syncing or experiencing other issues. For more information about this endpoint, visit <a href='https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Node/getSyncingStatus'>the beacon API documentation</a>.</p>
             </div>
         </div>
         <div className='task'>


### PR DESCRIPTION
missed changes on v5.1.1 we should direct users to use the standard APIs.

addresses https://github.com/prysmaticlabs/prysm/issues/14543

note this issue has not been resolved at the time of this PR: https://github.com/prysmaticlabs/prysm/issues/14226