### PR TITLE
Typo Update bugreports.md

### DIFF
--- a/website/docs/contribute/bugreports.md
+++ b/website/docs/contribute/bugreports.md
@@ -14,7 +14,7 @@ Bug reports are critical to the rapid development of the Prysm client. In order 
 
 Duplicate tickets are a hinderance to the development process and, as such, it is crucial to first check through Prysm's existing issues to see if what you are experiencing has already been indexed.
 
-To do so, head over to the [issue page](https://github.com/prysmaticlabs/prysm/issues) and enter some related keywords into the search bar. This may include a sample from the output or specific components it affects. If this is unsuccessful, check the [issue labels index](https://github.com/prysmaticlabs/prysm/labels) for related catagories and review the tickets within.
+To do so, head over to the [issue page](https://github.com/prysmaticlabs/prysm/issues) and enter some related keywords into the search bar. This may include a sample from the output or specific components it affects. If this is unsuccessful, check the [issue labels index](https://github.com/prysmaticlabs/prysm/labels) for related categories and review the tickets within.
 
 If searches have shown the issue in question has not been reported yet, feel free to open up a new issue ticket.
 


### PR DESCRIPTION
<img width="876" alt="Снимок экрана 2024-11-10 в 16 08 19" src="https://github.com/user-attachments/assets/125d33b7-8b7e-4be5-bfd2-7027f97e6e54">

The word "catagories" should be spelled as "**categories**."

Corrected.