### PR TITLE
fix: typos in documentation files

### DIFF
--- a/website/docs/devtools/end-to-end.md
+++ b/website/docs/devtools/end-to-end.md
@@ -8,7 +8,7 @@ import {HeaderBadgesWidget} from '@site/src/components/HeaderBadgesWidget.js';
 
 <HeaderBadgesWidget />
 
-Even the best unit tests won't prevent bugs from creeping into the system. They test small pieces of code in isolation, but it might be the interaction between different modules/packages/subsystems that causes issues. Prysm consist of two separate components, the beacon chain and the validator, that interact with each other in non-trivial ways. Additionally, the system contacts an Eth1 endpoint to access various information about the Eth1 chain. It is therefore very important to find integration bugs as soon as possible. The way Prysm achieves this is through having an E2E (end-to-end) test module. Tests inside this module are ran on every PR build, which greatly increases confidence that new code can safely be merged.
+Even the best unit tests won't prevent bugs from creeping into the system. They test small pieces of code in isolation, but it might be the interaction between different modules/packages/subsystems that causes issues. Prysm consists of two separate components, the beacon chain and the validator, that interact with each other in non-trivial ways. Additionally, the system contacts an Eth1 endpoint to access various information about the Eth1 chain. It is therefore very important to find integration bugs as soon as possible. The way Prysm achieves this is through having an E2E (end-to-end) test module. Tests inside this module are run on every PR build, which greatly increases confidence that new code can safely be merged.
 
 ## Running E2E tests
 

--- a/website/docs/wallet/web3signer.md
+++ b/website/docs/wallet/web3signer.md
@@ -12,7 +12,7 @@ import {HeaderBadgesWidget} from '@site/src/components/HeaderBadgesWidget.js';
 
 Web3Signer follows the [Remote Signing API](https://github.com/ethereum/remote-signing-api) specification.
 
-Prysm supports the use of Web3Signer the following flags:
+Prysm supports the use of Web3Signer with the following flags:
 
 `--validators-external-signer-url` : base URL for the Web3Signer.
 


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected "ran" to "run" - the correct form of the verb is used in the passive voice.
Corrected "consist" to "consists" - the error in subject-verb agreement in the singular has been corrected.
Also, "with" was added in the sentence where it is better to use it for correct grammatical structure

Please review the changes and let me know if any additional changes are needed.