### PR TITLE
Grammar and Clarity Improvements

### DIFF
--- a/website/docs/advanced/migrating-keys.md
+++ b/website/docs/advanced/migrating-keys.md
@@ -31,7 +31,7 @@ The migration process is straightforward and not too dissimilar to backing up an
 Exporting the slashing protection database is a real-time process and can be undertaken at any time. During migration, you should run the export once you have stopped the validator you are migrating away from. This ensures all validator actions are captured and subsequently imported into the new validator process.  
 :::
 
-To export your slashing protection history, use Prysm's built in commands which will work with any installation method.
+To export your slashing protection history, use Prysm's built-in commands which will work with any installation method.
 
 :::info
 

--- a/website/docs/advanced/proof-of-stake-devnet.md
+++ b/website/docs/advanced/proof-of-stake-devnet.md
@@ -26,7 +26,7 @@ Notwithstanding, more complex applications may want an environment that is close
 
 Today, running an Ethereum node require **two components**:
 
-1.  **execution client software** in charge of processing transactions and smart contracts. Example of execution client softwares are: [go-ethereum](https://geth.ethereum.org), [besu](https://besu.hyperledger.org/), [erigon](https://github.com/ledgerwatch/erigon), [nethermind](https://nethermind.io/) or [reth](https://paradigmxyz.github.io/reth/).
+1.  **execution client software** in charge of processing transactions and smart contracts. Example of execution client software are: [go-ethereum](https://geth.ethereum.org), [besu](https://besu.hyperledger.org/), [erigon](https://github.com/ledgerwatch/erigon), [nethermind](https://nethermind.io/) or [reth](https://paradigmxyz.github.io/reth/).
 2.  **consensus client software** in charge of running the proof-of-stake logic. This tutorial will use the [Prysm](https://github.com/prysmaticlabs/prysm) implementation, which my team develops.
 
 Prysm is an open source, Go implementation of the Ethereum proof-of-stake protocol. It can be used to run a node+validator client on mainnet and testnet environments with ease, and is highly configurable to meet users’ needs.
@@ -398,7 +398,7 @@ Your Prysm validator client should look as follows:
     ...
 
     
-## Using our newsly created devnet.
+## Using our newly created devnet.
 The devnet you just launched is a full-fledged Ethereum network. This means you can deploy smart contracts, call these smart contracts, send some Ethers from one account to an other etc...
 
 ### Send ETH using the go-ethereum console.
@@ -431,7 +431,7 @@ Now, send `1 ETH` from our address `0x123463a4b065722e99115d6c222f267d9cabb524` 
         value: web3.toWei(1, "ether")
     })
 
-Just after doing that, go-ethereum logs should containt:
+Just after doing that, go-ethereum logs should contain:
 
     INFO [01-10|15:42:22.550] Submitted transaction                    hash=0x4ac2a0e386ed41d8c56cf83226c44eba0858170a0964941b1f722dd54bb79e4d from=0x123463a4B065722E99115D6c222f267d9cABb524 nonce=0 recipient=0x123C0ffeE567BeeF890DECadE123FaDe456BeD78 value=1,000,000,000,000,000,000
     INFO [01-10|15:42:23.246] Updated payload                          id=0xd1f71f92ca68ab12 number=79 hash=da5ebe..271e9d txs=1 withdrawals=0 gas=21000 fees=2.1e-05 root=088b29..07ccf1 elapsed="365.625µs"

--- a/website/docs/advanced/switch-clients.md
+++ b/website/docs/advanced/switch-clients.md
@@ -49,7 +49,7 @@ We have a section dedicated to exporting and importing slashing protection histo
 
 ### Step 4: Update port forwarding
 
-This step is not required for nodes which are running on a virtual public cloud, but keep in mind - nodes will be required to run a an execution client locally post merge!  
+This step is not required for nodes which are running on a virtual public cloud, but keep in mind - nodes will be required to run an execution client locally post merge!  
 
 By default, Prysm uses TCP/13000 and UDP/12000. Remove those two rules and replace them with the appropriate port forwards for the client you are switching to. The process will be very similar to the steps laid out [here.](https://docs.prylabs.network/docs/prysm-usage/p2p-host-ip#port-forwarding) 
 
@@ -145,7 +145,7 @@ https://chainsafe.github.io/lodestar/run/validator-management/validator-cli#vali
 
 ### Step 7: Start the New Validator
 
-Ensure your beacon node is fully synced with the network by checking your clients logs prior to starting your validator. Once it is fully synced, start the validator.  
+Ensure your beacon node is fully synced with the network by checking your client's logs prior to starting your validator. Once it is fully synced, start the validator.  
 
 Search a block explorer like https://beaconcha.in with your validator's public key to confirm that your validator is now active!
 

--- a/website/docs/concepts/slashing.md
+++ b/website/docs/concepts/slashing.md
@@ -8,7 +8,7 @@ import {HeaderBadgesWidget} from '@site/src/components/HeaderBadgesWidget.js';
 
 <HeaderBadgesWidget />
 
-**Slashing** is a mechanism designed to encourage good behavior on the Ethereum network and discourage attacks and bad behavior. Where a validator is found to have broken the rules it will be slashed and removed from the network. In addition to being removed from the network, the entire validator stake may be removed. 
+**Slashing** is a mechanism designed to encourage good behavior on the Ethereum network and discourage attacks and bad behavior. When a validator is found to have broken the rules it will be slashed and removed from the network. In addition to being removed from the network, the entire validator stake may be removed. 
 
 Being slashed is the result of a validator undertaking one of three “bad” actions: 
 


### PR DESCRIPTION
1. Fix built-in command description: Changed "built in" to "built-in".
2. Correct software terminology: Changed "softwares" to "software".
3. Correct spelling error: Changed "newsly" to "newly".
4. Correct spelling in logs description: Changed "containt" to "contain".
5. Fix duplicate article: Removed duplicate "a" in "a an execution client".
6. Add possessive apostrophe: Changed "clients logs" to "client's logs".
7. Correct conjunction usage: Changed "Where" to "When" for clarity.