### PR TITLE
Typo Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository houses all the documentation pertaining to the Prysm client and Ethereum 2. It is generated with [Docusaurus](https://github.com/facebook/docusaurus). 
 
-Below are steps for initialising and reproducing this portal for development.
+Below are steps for initializing and reproducing this portal for development.
 
 ## Dependencies
 


### PR DESCRIPTION
**Description:**

There is a minor typo in the documentation under the section "Below are steps for initialising and reproducing this portal for development." 

The word **"initialising"** should be spelled as **"initializing"** to match American English, which is the standard in IT terminology and documentation. Using consistent American English improves readability and maintains a professional, standardized tone, especially since most technical documentation, libraries, and resources default to this variant. 

**Changes Made:**

- Corrected "initialising" to "initializing" in the relevant section.

This change helps maintain consistency and clarity for a global audience accustomed to American English in technical contexts.