### PR TITLE
Typo Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository houses all the documentation pertaining to the Prysm client and Ethereum 2. It is generated with [Docusaurus](https://github.com/facebook/docusaurus). 
 
-Below are steps for initialising and reproducing this portal for development.
+Below are steps for initializing and reproducing this portal for development.
 
 ## Dependencies
 


### PR DESCRIPTION
**Description**:

This PR fixes a spelling inconsistency in the documentation. The word **"initialising"** has been changed to **"initializing"**.

**Issue**:

- The word **"initialising"** is the British spelling, whereas **"initializing"** is the preferred American English spelling in programming documentation. Using consistent American English spelling in code-related documentation is important to ensure clarity and uniformity across projects.

**Importance**:

- Standardizing spelling across the documentation helps maintain professionalism and ensures the documentation aligns with the conventions commonly used in the software development community. This small change contributes to a more polished and consistent user experience.

Please review and approve the change.
