### PR TITLE
Corrected grammatical and terminology issues in documentation

### DIFF
--- a/website/docs/advanced/proof-of-stake-devnet.md
+++ b/website/docs/advanced/proof-of-stake-devnet.md
@@ -24,7 +24,7 @@ Notwithstanding, more complex applications may want an environment that is close
 
 ## Setting up
 
-Today, running an Ethereum node require **two components**:
+Today, running an Ethereum node requires **two components**:
 
 1.  **execution client software** in charge of processing transactions and smart contracts. Example of execution client softwares are: [go-ethereum](https://geth.ethereum.org), [besu](https://besu.hyperledger.org/), [erigon](https://github.com/ledgerwatch/erigon), [nethermind](https://nethermind.io/) or [reth](https://paradigmxyz.github.io/reth/).
 2.  **consensus client software** in charge of running the proof-of-stake logic. This tutorial will use the [Prysm](https://github.com/prysmaticlabs/prysm) implementation, which my team develops.

--- a/website/docs/advanced/switch-clients.md
+++ b/website/docs/advanced/switch-clients.md
@@ -51,7 +51,7 @@ We have a section dedicated to exporting and importing slashing protection histo
 
 This step is not required for nodes which are running on a virtual public cloud, but keep in mind - nodes will be required to run a an execution client locally post merge!  
 
-By default, Prysm uses TCP/13000 and UDP/12000. Remove those two rules and replace them with the appropriate port forwards for the client you are switching to. The process will be very similar to the steps laid out [here.](https://docs.prylabs.network/docs/prysm-usage/p2p-host-ip#port-forwarding) 
+By default, Prysm uses TCP/13000 and UDP/12000. Remove those two rules and replace them with the appropriate port forwarding for the client you are switching to. The process will be very similar to the steps laid out [here.](https://docs.prylabs.network/docs/prysm-usage/p2p-host-ip#port-forwarding) 
 
 Teku, Nimbus, and Lighthouse all use port 9000 for both TCP and UDP. 
 


### PR DESCRIPTION
**Description:**

This pull request addresses two issues found in the documentation files:

1. **File: `website/docs/advanced/proof-of-stake-devnet.md`**
   - **Issue**: The sentence "Today, running an Ethereum node require two components:" contains a grammatical error. The word "require" should be changed to "requires" to agree with the singular subject "node."
   - **Fix**: The sentence is now correctly written as:
     > "Today, running an Ethereum node requires two components:"
   - **Importance**: This fix ensures that the sentence is grammatically correct, improving readability and professionalism in the documentation.

2. **File: `website/docs/advanced/switch-clients.md`**
   - **Issue**: The phrase "port forwards" is used incorrectly in the sentence: "Remove those two rules and replace them with the appropriate port forwards for the client you are switching to." The term "port forwards" should be changed to "port forwarding," as it refers to the process rather than a plural noun.
   - **Fix**: The corrected sentence reads:
     > "Remove those two rules and replace them with the appropriate port forwarding for the client you are switching to."
   - **Importance**: This adjustment ensures that the terminology is accurate, helping users understand the intended action clearly and avoid confusion.

Both changes contribute to a more polished and precise documentation experience for developers and users.