### PR TITLE
Fix bazel build typo

### DIFF
--- a/website/docs/reading/bazel.md
+++ b/website/docs/reading/bazel.md
@@ -85,7 +85,7 @@ Everything in Prysm can be built with Bazel using
 
 For example, the beacon node can be built with
 
-    bazel build /cmd/beacon-chain --config=release 
+    bazel build //cmd/beacon-chain --config=release 
     
 The `--config=release` will apply all compile-time optimizations to the code, and build everything including C dependencies and our cryptography from source. Every package in the Prysm monorepo can be build with
 


### PR DESCRIPTION
There is a typo in the section describing how to build production releases with bazel. This PR fixes it.