### PR TITLE
Fix typo contribution-guidelines.md

### DIFF
--- a/website/docs/contribute/contribution-guidelines.md
+++ b/website/docs/contribute/contribution-guidelines.md
@@ -63,7 +63,7 @@ Please define the following environment variable when running tests:
 
     CGO_CFLAGS="-O2 -D__BLST_PORTABLE__"
 
-It is particulary useful when running tests / debug in your IDE without using bazel.
+It is particularly useful when running tests / debug in your IDE without using bazel.
 
 See the [next section](#building-and-testing-prysm-with-bazel) for instructions on testing with prysm.
 


### PR DESCRIPTION
## Pull Request Description

### What this PR does:
- Fixes a typo in `contribution-guidelines.md`.

### Changes:
- Corrected the word "particulary" to "particularly" on line 63 of `website/docs/contribute/contribution-guidelines.md`.

### Motivation:
- Ensures consistency and accuracy in the documentation.

### Related Issues:
- Fixes issue # (if applicable).
