### PR TITLE
docs: fix work of badges

### DIFF
--- a/docs/advanced/proof-of-stake-devnet.md
+++ b/docs/advanced/proof-of-stake-devnet.md
@@ -6,6 +6,6 @@ sidebar_label: Configure a devnet
 
 import {HeaderBadgesWidget} from '@site/src/components/HeaderBadgesWidget.js';
 
-<HeaderBadgesWidget commaDelimitedContributors="Raul, Sammy, James" />
+<HeaderBadgesWidget commaDelimitedContributors="Raul,Sammy,James" />
 
 This page is now deprecated in favor of running a devnet using the [Kurtosis tool](https://github.com/ethpandaops/ethereum-package) for running and testing Prysm. Kurtosis is highly maintained and is the recommended way to set up a Prysm devnet locally.


### PR DESCRIPTION
Badges Sammy and James are not working on this [page ](https://www.offchainlabs.com/prysm/docs/advanced/proof-of-stake-devnet/) because of spaces. Now it will work properly. 