### PR TITLE
chore: replace broken links

### DIFF
--- a/docs/apis/prysm-public-api.md
+++ b/docs/apis/prysm-public-api.md
@@ -17,7 +17,7 @@ For a standard API that all Ethereum beacon nodes implement, see [here](/apis/et
 
 One of the required components of nodes in the Ethereum beacon chain network is to expose an API server for outside interaction. This API is critical for running validators on Ethereum, as validator clients can connect to nodes and query their API to figure out their assigned duties, to submit block proposals, and more. Prysm's Ethereum consensus API schema is maintained in Prysm itself here: [github.com/OffchainLabs/prysm/proto](https://github.com/OffchainLabs/prysm/tree/develop/proto) and is implemented by Prysm beacon nodes and validators.
 
-![gRPC](/images/grpc-logo2.png)
+![gRPC](https://github.com/OffchainLabs/prysm-documentation/blob/master/static/images/grpc-logo2.png)
 
 Prysm implements its API by using the popular [gRPC](https://grpc.io) project created by Google, providing highly advanced functionality for Ethereum consensus. Interacting with the API requires the use of protocol buffers, also known as protobuf. These [protocol buffer](https://developers.google.com/protocol-buffers/). For information on the functionality of gRPC and protocol buffers more generally, see the [gRPC guide](https://grpc.io/guides/).
 
@@ -43,7 +43,7 @@ Some Prysm specific endpoints are still supported via REST under the prysm/v1 na
 
 * [Awesome gRPC](https://github.com/grpc-ecosystem/awesome-grpc)
 * [Google's API Style Guide](https://cloud.google.com/apis/design/)
-* [Language reference for proto 3](https://developers.google.com/protocol-buffers/proto3)
-* [Protocol Buffer Basics: Go](https://developers.google.com/protocol-buffers/gotutorial)
+* [Language reference for proto 3](https://protobuf.dev/programming-guides/proto3)
+* [Protocol Buffer Basics: Go](https://protobuf.dev/getting-started/gotutorial)
 * [Transcoding gRPC to JSON/HTTP using Envoy](https://blog.jdriven.com/2018/11/transcoding-grpc-to-http-json-using-envoy/)
 * [gRPCurl](https://github.com/fullstorydev/grpcurl)


### PR DESCRIPTION
Replaced outdated Google Protocol Buffers links with new protobuf.dev URLs for proto3 and Go tutorial.

Reopen: https://github.com/OffchainLabs/prysm-documentation/pull/1069