### PR TITLE
docs: add UDP to port 13000 requirement

### DIFF
--- a/docs/manage-connections/configure-ports-and-firewalls.md
+++ b/docs/manage-connections/configure-ports-and-firewalls.md
@@ -55,7 +55,7 @@ The following firewall rules should be configured on any local operating system,
 | `8551/TCP`      | Block all traffic.                  | Your beacon node connects to your execution node's [Engine API](https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md) using this port. Inbound and outbound traffic should be allowed through this port only if your local beacon node is connecting to a remote execution node. |
 | `4000/TCP`      | Block all traffic.                  | Your validator uses this port to connect to your beacon node via [gRPC](https://grpc.io). Inbound and outbound traffic should be allowed through this port only if your local validator is connecting to a remote beacon node.                                                                               |
 | `*/UDP+TCP`     | Allow outbound traffic.             | To [discover](https://github.com/ethereum/devp2p/wiki/Discovery-Overview) peers, Prysm's beacon node dials out through random ports. Allowing outbound TCP/UDP traffic from any port will help Prysm find peers.                                                                                             |
-| `13000/TCP`     | Allow inbound and outbound traffic. | After we discover peers, we dial them through this port to establish an ongoing connection for [`libp2p`](https://libp2p.io/) and through which all gossip/p2p request and responses will flow.                                                                                                                |
+| `13000/TCP+UDP` | Allow inbound and outbound traffic. | After we discover peers, we dial them through this port to establish an ongoing connection for [`libp2p`](https://libp2p.io/) and through which all gossip/p2p request and responses will flow.                                                                                                                |
 | `12000/UDP`     | Allow inbound and outbound traffic. | Your beacon node exposes this UDP port so that other Ethereum nodes can discover your node, request chain data, and provide chain data.                                                                                                                                                                      |
 | `30303/TCP+UDP` | Allow inbound and outbound traffic. | `30303/TCP` is your execution node's listener port, while `30303/UDP` is its discovery port. This rule lets your execution node connect to other peers. Note that some clients use `30301` by default.                                                                                                       |
 
@@ -114,7 +114,7 @@ import MultidimensionalContentControlsPartial from '@site/docs/partials/_multidi
 
 > If you're running on a virtual public cloud (VPC) instance, you can skip this step.
 
-To ensure that other peer nodes can discover your node, you may need to forward ports `13000/TCP` and `12000/UDP` using your router's admin interface. Every router is different, but the procedure is usually something like this:
+To ensure that other peer nodes can discover your node, you may need to forward ports `13000/TCP+UDP` and `12000/UDP` using your router's admin interface. Every router is different, but the procedure is usually something like this:
 
 1. Determine your router's IP address
 2. Log in to your router's browser-based admin interface (usually something like http://192.168.1.1)
@@ -122,7 +122,7 @@ To ensure that other peer nodes can discover your node, you may need to forward 
 4. Configure a port forwarding rule with the following values:
     - External port: `13000`
     - Internal port: `13000`
-    - Protocol: `TCP`
+    - Protocol: `TCP` and `UDP` (you may need to create two separate rules)
     - IP Address: The private IP address of the computer running your beacon node
 5. Configure a second port forwarding rule with the following values:
     - External port: `12000`


### PR DESCRIPTION
## Summary
- Updates firewall documentation to indicate port 13000 requires both TCP and UDP (not just TCP)
- Updates router port forwarding instructions to include UDP for port 13000

## Test plan
- Review the rendered documentation

Fixes #1140