### PR TITLE
docs: fix stale CLI flags, Docker command continuation, and auth-token wording

### DIFF
--- a/docs/apis/keymanager-api.md
+++ b/docs/apis/keymanager-api.md
@@ -12,7 +12,7 @@ Please refer to the "local keystores APIs" to manage locally stored validator ke
 Go to our [Web3Signer](/manage-wallet/use-web3signer.md) docs page for more information.
 
 ## Authentication
-A JWT token is needed to use the Keymanager APIs. This token is automatically generated and can be found on the second line of the `auth-token` file, located in the Prysm wallet directory. The Prysm wallet directory is defined by the `--wallet-dir` flag default or custom value, and is also displayed in the Validator Client logs at start.
+A JWT token is needed to use the Keymanager APIs. This token is automatically generated and can be found as the contents of the `auth-token` file (a single-line file), located in the Prysm wallet directory. The Prysm wallet directory is defined by the `--wallet-dir` flag default or custom value, and is also displayed in the Validator Client logs at start.
 
 The JWT token itself is directly displayed at the Validator Client start as well, in this log:
 

--- a/docs/apis/keymanager-api.md
+++ b/docs/apis/keymanager-api.md
@@ -12,7 +12,7 @@ Please refer to the "local keystores APIs" to manage locally stored validator ke
 Go to our [Web3Signer](/manage-wallet/use-web3signer.md) docs page for more information.
 
 ## Authentication
-A JWT token is needed to use the Keymanager APIs. This token is automatically generated and can be found as the contents of the `auth-token` file (a single-line file), located in the Prysm wallet directory. The Prysm wallet directory is defined by the `--wallet-dir` flag default or custom value, and is also displayed in the Validator Client logs at start.
+A JWT token is needed to use the Keymanager APIs. This token is automatically generated and can be found in the contents of the single-line file `auth-token`, located in the Prysm wallet directory. The Prysm wallet directory is defined by the `--wallet-dir` flag default or custom value, and is also displayed in the Validator Client logs at start.
 
 The JWT token itself is directly displayed at the Validator Client start as well, in this log:
 

--- a/docs/configure-prysm/configure-mev-builder.md
+++ b/docs/configure-prysm/configure-mev-builder.md
@@ -216,7 +216,7 @@ Values stored in the bolt db will not be cleared and you will not be able to unr
 
 ### Parallel execution
 
-By default the beacon node will construct the consensus and execution portions of the beacon block in parallel to improve speed and efficiency. `--disable-build-block-parallel` flag can be added to prevent node from building in parallel and will build sequentially. 
+By default the beacon node will construct the consensus and execution portions of the beacon block in parallel to improve speed and efficiency. This is standard behavior with no opt-out flag available.
 
 ### Prioritizing local blocks
 

--- a/docs/configure-prysm/configure-mev-builder.md
+++ b/docs/configure-prysm/configure-mev-builder.md
@@ -214,10 +214,6 @@ Values stored in the bolt db will not be cleared and you will not be able to unr
 
 :::
 
-### Parallel execution
-
-By default the beacon node will construct the consensus and execution portions of the beacon block in parallel to improve speed and efficiency. This is standard behavior with no opt-out flag available.
-
 ### Prioritizing local blocks
 
 `--local-block-value-boost` flag is a `uint64` value that provides an additional percentage to multiply the local block value. Use builder block if: `builder_bid_value * 100 > local_block_value * (local-block-value-boost + 100)`. This will encourage your setup to use the local execution if the value earned is not above your threshold, helping to mitigate censorship concerns.

--- a/docs/install-prysm/install-with-docker.md
+++ b/docs/install-prysm/install-with-docker.md
@@ -312,7 +312,7 @@ docker run -it -v $HOME/Eth2Validators/prysm-wallet-v2:/wallet \
   gcr.io/offchainlabs/prysm/validator:stable \
   --beacon-rpc-provider=127.0.0.1:4000 \
   --wallet-dir=/wallet \
-  --datadir=/validatorDB
+  --datadir=/validatorDB \
   --suggested-fee-recipient=<YOUR_WALLET_ADDRESS>
 ```
 

--- a/docs/manage-connections/configure-ports-and-firewalls.md
+++ b/docs/manage-connections/configure-ports-and-firewalls.md
@@ -67,10 +67,10 @@ Both consensus and execution clients allow you to customize many of these ports.
 
 :::tip Cloud Users
 
-If running on a cloud provider (AWS, GCP, Azure, etc.), consider blacklisting internal IP ranges to prevent connectivity issues. Add this flag to your beacon node:
+If running on a cloud provider (AWS, GCP, Azure, etc.), consider denylisting internal IP ranges to prevent connectivity issues. Add this flag to your beacon node:
 
 ```
---p2p-blacklist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,100.64.0.0/10,169.254.0.0/16
+--p2p-denylist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,100.64.0.0/10,169.254.0.0/16
 ```
 
 :::

--- a/docs/manage-wallet/use-web3signer.md
+++ b/docs/manage-wallet/use-web3signer.md
@@ -79,7 +79,7 @@ Example:
 validator --web --validators-external-signer-url=http://localhost:9000
 ```
 
-The `--web` flag will enable validator client APIs as well as the web ui ( not supported for `web3signer` ). A JWT token ( found on the second line of the auth-token file) will be generated in the Prysm default wallet directory otherwise defined by `--wallet-dir` flag. the token will also be printed in the console:
+The `--web` flag will enable validator client APIs as well as the web ui ( not supported for `web3signer` ). A JWT token (found as the contents of the `auth-token` file, a single-line file) will be generated in the Prysm default wallet directory otherwise defined by `--wallet-dir` flag. The token will also be printed in the console:
 
 ```sh
 [2022-04-15 14:07:39]  INFO rpc: http://127.0.0.1:7500/initialize?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.ck3J6tcvHcI74IiFjyJqcBH-MmNAq-fMr0ncyZkGvFM

--- a/docs/manage-wallet/use-web3signer.md
+++ b/docs/manage-wallet/use-web3signer.md
@@ -79,7 +79,7 @@ Example:
 validator --web --validators-external-signer-url=http://localhost:9000
 ```
 
-The `--web` flag will enable validator client APIs as well as the web ui ( not supported for `web3signer` ). A JWT token (found as the contents of the `auth-token` file, a single-line file) will be generated in the Prysm default wallet directory otherwise defined by `--wallet-dir` flag. The token will also be printed in the console:
+The `--web` flag will enable validator client APIs as well as the web ui ( not supported for `web3signer` ). A JWT token (found in the contents of the single-line file `auth-token`, will be generated in the Prysm default wallet directory otherwise defined by `--wallet-dir` flag. The token will also be printed in the console:
 
 ```sh
 [2022-04-15 14:07:39]  INFO rpc: http://127.0.0.1:7500/initialize?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.ck3J6tcvHcI74IiFjyJqcBH-MmNAq-fMr0ncyZkGvFM


### PR DESCRIPTION
## What's fixed
- Added the missing trailing `\` before `--suggested-fee-recipient` in the Linux Docker **validator** run command (`install-with-docker.md`) so the multi-line command is valid.
- `--p2p-blacklist` → `--p2p-denylist` (`configure-ports-and-firewalls.md`).
- Removed  `Parellel Execution` part.
- Fixed Web3Signer / Keymanager auth-token wording: the JWT is the **single-line** contents of the `auth-token` file (two-line files are legacy), no longer "the second line" (`keymanager-api.md`, `use-web3signer.md`).

## Why
- The current flag is `p2p-denylist` — [cmd/flags.go#L175](https://github.com/OffchainLabs/prysm/blob/49b1c81cd57d6ba8f4a5a1698284750e9e7cc546/cmd/flags.go#L175)
- `--disable-build-block-parallel` was removed — [CHANGELOG.md#L307](https://github.com/OffchainLabs/prysm/blob/49b1c81cd57d6ba8f4a5a1698284750e9e7cc546/CHANGELOG.md#L307)
- The auth-token is written as a single line; two-line files are explicitly handled as legacy — [auth_token.go#L134](https://github.com/OffchainLabs/prysm/blob/49b1c81cd57d6ba8f4a5a1698284750e9e7cc546/validator/rpc/auth_token.go#L134) (write) / [#L187](https://github.com/OffchainLabs/prysm/blob/49b1c81cd57d6ba8f4a5a1698284750e9e7cc546/validator/rpc/auth_token.go#L187) (legacy warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
