### PR TITLE
docs: correct database backup guide for removed webhook and output-dir flags

### DIFF
--- a/docs/backup-and-migration/backup-and-restore.md
+++ b/docs/backup-and-migration/backup-and-restore.md
@@ -108,13 +108,25 @@ bazel run //cmd/beacon-chain -- db restore --restore-source-file=/path/to/backup
 
 ## Validator client
 
-### Add the backup flag to your validator client 
+### Backing up the database manually
 
-Add the following flag to your validator client:
+Stop the validator client before copying its database files to avoid capturing a partially-written state.
 
-- `--db-backup-output-dir`: Folder path to where backups will be output to, such as `/path/to/mybackups`.
+Your first need to find your base directory. If you don't usually run your validator client with the `--datadir` option, then you can find the base directory by running your validator client with the `--help` option. It will vary depending on the operating system you use.
 
-Now, your validator client will expose an HTTP endpoint `http://monitoringhost:monitoringport/db/backup`, which is `http://127.0.0.1:8081/db/backup` by default. You can hit this endpoint using curl or any other tool you prefer, and a backup will initiate which will be output to your `--db-backup-output-dir` path.
+The validator database file is located at `validator.db` inside your data directory.
+
+:::note Default backup output directory
+
+When a programmatic backup is triggered (for example, by tooling that calls the `Backup` method directly), the output is written to the `backups/` subdirectory of your data directory — for example, `$DATADIR/backups/prysm_validatordb_<timestamp>.backup`.
+
+:::
+
+:::note Removed and deprecated flags
+
+The `--db-backup-output-dir` flag has been removed. The `--enable-db-backup-webhook` flag is deprecated and no longer has any effect — the `/db/backup` HTTP endpoint is no longer registered by the validator client.
+
+:::
 
 
 ### Restoring from a backup


### PR DESCRIPTION
## What's fixed
- Removed instructions for the removed `--db-backup-output-dir` flag and the `/db/backup` HTTP webhook trigger.
- Documented the actual default backup location, `$DATADIR/backups`.
- Reframed the guide around offline/manual backup, since the live webhook trigger no longer exists.

## Why
- `--db-backup-output-dir` was moved to deprecated/removed — [CHANGELOG.md#L1891](https://github.com/OffchainLabs/prysm/blob/49b1c81cd57d6ba8f4a5a1698284750e9e7cc546/CHANGELOG.md#L1891)
- `--enable-db-backup-webhook` is now a hidden deprecated flag ("DEPRECATED. DO NOT USE.") — [config/features/deprecated_flags.go#L23](https://github.com/OffchainLabs/prysm/blob/49b1c81cd57d6ba8f4a5a1698284750e9e7cc546/config/features/deprecated_flags.go#L23)
- The default backup directory is `$DATADIR/backups` — [beacon-chain/db/kv/backup.go#L31](https://github.com/OffchainLabs/prysm/blob/49b1c81cd57d6ba8f4a5a1698284750e9e7cc546/beacon-chain/db/kv/backup.go#L31) / [validator/db/kv/backup.go#L15](https://github.com/OffchainLabs/prysm/blob/49b1c81cd57d6ba8f4a5a1698284750e9e7cc546/validator/db/kv/backup.go#L15)
- The `/db/backup` handler still exists but is no longer registered by either the beacon node or the validator HTTP server — [monitoring/backup/http_backup_handler.go](https://github.com/OffchainLabs/prysm/blob/49b1c81cd57d6ba8f4a5a1698284750e9e7cc546/monitoring/backup/http_backup_handler.go)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
