### PR TITLE
docs: refresh prysmctl and checkpoint-sync instructions

### DIFF
--- a/docs/configure-prysm/prysmctl.md
+++ b/docs/configure-prysm/prysmctl.md
@@ -27,7 +27,7 @@ Example of running `prysmctl` by opening a terminal at the installed location af
 ./prysmctl --help
 ```
 
-The binaries can be run through a terminal directly and won't need installation. Please refer to the [list commands](#list-commands section for additional information. 
+The binaries can be run through a terminal directly and won't need installation. Please refer to the [list commands](#list-commands) section for additional information.
 
 ### Install via source
 
@@ -64,7 +64,7 @@ Clone Prysm's [main repository](https://github.com/OffchainLabs/prysm). Switch t
 
 ```sh
 git clone https://github.com/OffchainLabs/prysm && cd prysm
-``````
+```
 
 #### Build `prysmctl`
 
@@ -85,7 +85,7 @@ Bazel will automatically pull and install any dependencies as well, including Go
 docker run -it gcr.io/offchainlabs/prysm/cmd/prysmctl:latest --help
 ```
 
-The `—-help` flag will provide a list of commands, subcommands, and flags to use.
+The `--help` flag will provide a list of commands, subcommands, and flags to use.
 
 Commands can also be found in our [Prysm parameter documentation](/configure-prysm/command-line-options.md)
 

--- a/docs/configure-prysm/sync-from-a-checkpoint.md
+++ b/docs/configure-prysm/sync-from-a-checkpoint.md
@@ -83,25 +83,24 @@ The beacon node *requesting* the checkpoint state from this node doesn't need th
 
 When you sync via **network request**, the `BeaconState`, `SignedBeaconBlock`, and genesis state files are delivered from one beacon node to another using a peer-to-peer connection. When you sync via **file export/import**, you manually export these files from one beacon node and import them into another. This can be useful if you don't want your beacon node to expose an RPC gateway provider endpoint. Block explorers and client teams can also host these exported files statically as a trusted checkpoint sync source.
 
-Issue the following commands to export the `BeaconState` and `SignedBeaconBlock` files from a synced beacon node using `prysmctl`. Until `prysmctl` is included in Prysm's binary release package, it is necessary to run it from a local source checkout:
+Issue the following commands to export the `BeaconState` and `SignedBeaconBlock` files from a synced beacon node using `prysmctl`. You can run `prysmctl` via a downloaded binary, Docker, or directly with `go run`:
 
-:::info
-
-Installing `prysmctl` via `prysm.sh`, or downloading it from Prysm's GitHub release page, will be possible in an upcoming stable release.
-
-:::
+**Binary** — download the `prysmctl` binary for your platform from the [latest Prysm release page](https://github.com/OffchainLabs/prysm/releases), make it executable, then run:
 
 ```bash
-$ git clone git@github.com:OffchainLabs/prysm.git
-Cloning into 'prysm'...
-remote: Enumerating objects: 167386, done.
-remote: Counting objects: 100% (332/332), done.
-remote: Compressing objects: 100% (234/234), done.
-remote: Total 167386 (delta 118), reused 220 (delta 93), pack-reused 167054
-Receiving objects: 100% (167386/167386), 154.30 MiB | 39.56 MiB/s, done.
-Resolving deltas: 100% (127482/127482), done.
+$ ./prysmctl checkpoint-sync download --beacon-node-host=http://localhost:3500
+```
 
-$ go run github.com/OffchainLabs/prysm/v3/cmd/prysmctl checkpoint-sync download --beacon-node-host=http://localhost:3500
+**Docker**:
+
+```bash
+$ docker run --rm gcr.io/offchainlabs/prysm/cmd/prysmctl:latest checkpoint-sync download --beacon-node-host=http://localhost:3500
+```
+
+**Build from source** (`go run`):
+
+```bash
+$ go run github.com/OffchainLabs/prysm/v7/cmd/prysmctl checkpoint-sync download --beacon-node-host=http://localhost:3500
 ```
 
 You should see the following output if your export was successful:


### PR DESCRIPTION
## What's fixed
- Updated stale `github.com/OffchainLabs/prysm/v3` examples to the current module path `…/prysm/v7`.
- Removed "upcoming release" language; documented prysmctl via binary download, Docker, and `go run`, using the correct `prysmctl checkpoint-sync download` subcommand.
- Fixed markdown render issues in `prysmctl.md`: a malformed anchor link, a malformed code fence, and the `—-help` (em-dash) → `--help` typo.

## Why
- The current module major version is `v7` — [go.mod#L1](https://github.com/OffchainLabs/prysm/blob/49b1c81cd57d6ba8f4a5a1698284750e9e7cc546/go.mod#L1)
- prysmctl provides the `checkpoint-sync` command — [cmd/prysmctl/checkpointsync/cmd.go#L7](https://github.com/OffchainLabs/prysm/blob/49b1c81cd57d6ba8f4a5a1698284750e9e7cc546/cmd/prysmctl/checkpointsync/cmd.go#L7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
