### PR TITLE
docs: rewrite fallback beacon nodes page with accurate flag attribution

### DIFF
--- a/docs/configure-prysm/fallback-beacon-nodes.md
+++ b/docs/configure-prysm/fallback-beacon-nodes.md
@@ -4,78 +4,106 @@ title: Enhance validator reliability with fallback beacon nodes
 sidebar_label: Add fallback beacon nodes
 ---
 
-To configure a validator using Prysm with fallback beacon nodes, you can leverage Prysm's built-in support for multiple beacon node endpoints. The fallback provides load balancing and redundancy—if one beacon node becomes unresponsive, the validator client will automatically fall back to the others. The configuration uses the `--beacon-rpc-provider` with comma-separated gRPC endpoints (e.g., `host:port` pairs) or the `--beacon-rest-api-provider` flag with with comma-separated HTTP URLs (e.g., `http://localhost:3500,http://remote:3500`).
+Prysm's validator client supports multiple beacon node endpoints for redundancy and load balancing. If the active endpoint becomes unresponsive or unsynced, the validator automatically fails over to the next endpoint in the list.
 
 ### Prerequisites
 
-- Ensure you have Prysm installed (e.g., via binaries from the official releases or built from source).
-- Set up at least two beacon nodes (local or remote) that your validator can connect to. Each beacon node should be running and exposing its gRPC port (default: 4000).
-- Generate or import your validator keys and wallet (e.g., using `prysm validator wallet create`).
+- Prysm installed (via official release binaries or built from source).
+- At least two beacon nodes running and accessible from the machine running the validator client.
+- Validator keys and a wallet already created (e.g., via `prysm validator wallet create`).
 
-### Step-by-Step Configuration
+### Connecting with gRPC (default)
 
-1. **Run the Validator Client with Fallback Endpoints**:
+Use `--beacon-rpc-provider` on the **validator client** with a comma-separated list of `host:port` pairs. The gRPC port defaults to **4000**.
 
-   **gRPC** (default): Use `--beacon-rpc-provider` with comma-separated `host:port` pairs (gRPC port, default: 4000):
-   ```
-   ./prysm.sh validator \
-     --wallet-dir=/path/to/wallet \
-     --beacon-rpc-provider=localhost:4000,remote-beacon.example.com:4000,another-beacon:4000 \
-     --datadir=/path/to/validator/data \
-     --mainnet \
-     --suggested-fee-recipient=0xYourEthereumAddressForFees
-   ```
+```
+./prysm.sh validator \
+  --wallet-dir=/path/to/wallet \
+  --beacon-rpc-provider=localhost:4000,remote-beacon.example.com:4000,another-beacon:4000 \
+  --datadir=/path/to/validator/data \
+  --mainnet \
+  --suggested-fee-recipient=0xYourEthereumAddressForFees
+```
 
-   **REST**: Use `--beacon-rest-api-provider` with comma-separated HTTP URLs (REST port, default: 3500). Each beacon node must also be started with `--enable-beacon-rest-api`:
-   ```
-   ./prysm.sh validator \
-     --wallet-dir=/path/to/wallet \
-     --beacon-rest-api-provider=http://localhost:3500,http://remote-beacon.example.com:3500,http://another-beacon:3500 \
-     --datadir=/path/to/validator/data \
-     --mainnet \
-     --suggested-fee-recipient=0xYourEthereumAddressForFees
-   ```
+:::note gRPC deprecation
 
-   Other common flags:
-   - `--graffiti="YourCustomGraffiti"`: Optional, for [custom block graffiti](/manage-validator/add-graffiti.md).
-   - `--wallet-password-file=/path/to/password.txt`: For non-interactive runs.
-   - `--enable-doppelganger`: Enables doppelganger protection but may interfere with fallbacks in some cases (e.g., if the primary node is down during startup—test this in a dev environment).
-
-:::note Fallback behavior
-
-Both gRPC and REST use the same sync-status-aware failover logic: the validator checks that each candidate node is both reachable and fully synced before accepting it. If the current endpoint becomes unhealthy or unsynced, the validator tries each remaining host once in order and stops at the first healthy one. When a switch occurs, it logs `Failover succeeded` with the `previousHost`, `newHost`, and `failedAttempts` fields.
+gRPC will remain the default and fully supported through v8 (expected in 2026) but will eventually be removed in favor of the REST API.
 
 :::
 
-2. **Incorporate Health Checks (Including `maxHealthChecks` from [PR #15401](https://github.com/OffchainLabs/prysm/pull/15401))**:
-   - In the OffchainLabs/prysm fork, [Pull Request #15401](https://github.com/OffchainLabs/prysm/pull/15401) introduces enhancements for safe validator shutdowns and restarts based on health checks of the connected beacon nodes. This health check is instrumental in fallback setups, handling scenarios where all beacon nodes become unhealthy.
-   - (**Optional**) The key addition is the `--max-health-checks` flag, which controls the maximum number of consecutive failed health checks before the validator client times out and shuts down gracefully (allowing for restarts or manual intervention).
-     - **Usage**: Add it to your validator command, e.g.:
-       ```
-       ./prysm.sh validator \
-         --wallet-dir=/path/to/wallet \
-         --beacon-rpc-provider=localhost:4000,remote-beacon.example.com:4000 \
-         --max-health-checks=10 \
-         --datadir=/path/to/validator/data \
-         --mainnet
-       ```
-     - **Explanation of `maxHealthChecks`**:
-       - **Value**: An integer specifying the max failed checks (e.g., `10`). The validator will log warnings, such as "Failed health check, beacon node is unresponsive (fails=X maxFails=Y)" during issues.
-       - **Special value**: `0` for indefinite checks (no timeout, keeps retrying forever).
-       - Default: Not specified in the PR (check your build's flags with `--help`), but typically finite to prevent indefinite hangs.
-       - This flag works alongside fallbacks: If all endpoints fail health checks (e.g., syncing issues or connectivity loss), the counter increments until reaching the limit, triggering a shutdown. Its design is to improve reliability in multi-node setups, with compatibility for gRPC load balancing and multiple beacon node HTTP resolvers.
+### Connecting with REST
 
-3. **Monitoring and Testing**:
-   - Monitor logs for health check messages or fallback switches. When the validator switches endpoints, it logs `Failover succeeded` with `previousHost`, `newHost`, and `failedAttempts` fields. Debug-level logs (e.g., `Node is not ready`) are emitted during health checks.
-   - Use tools like [Prometheus and Grafana](/monitoring-alerts-metrics/grafana-dashboard.md) (enabled via `--monitoring-port=8081`) to track validator performance.
-   - **Test fallbacks**: Shut down one beacon node and verify the validator continues attesting/proposing via the others.
-   - If enabling features like MEV-Boost, add `--http-mev-relay=http://mev-relay.example.com` for external builders, with automatic fallback to local execution if needed.
+Use `--beacon-rest-api-provider` on the **validator client** with a comma-separated list of HTTP URLs. Also pass `--enable-beacon-rest-api` on the **validator client** to switch it from gRPC to REST when communicating with the beacon node. The beacon node's REST API is served on port **3500** by default (controlled on the beacon node side by `--http-port`, alias `--grpc-gateway-port`).
 
-### Potential Issues and Tips
+```
+./prysm.sh validator \
+  --wallet-dir=/path/to/wallet \
+  --beacon-rest-api-provider=http://localhost:3500,http://remote-beacon.example.com:3500,http://another-beacon:3500 \
+  --enable-beacon-rest-api \
+  --datadir=/path/to/validator/data \
+  --mainnet \
+  --suggested-fee-recipient=0xYourEthereumAddressForFees
+```
 
-- **Doppelganger Protection**: If enabled, it might prevent quick fallbacks during startup if the primary node is down. Disable it temporarily for testing.
-- **Network-Specific Flags**: Use `--mainnet`, `--holesky`, or `--sepolia` depending on your chain.
-- **Security**: Expose gRPC/HTTP ports securely (e.g., via TLS with `--tls-cert` and `--tls-key`).
-- For advanced setups (e.g., Kubernetes), use environment variables like `BEACON_RPC_PROVIDER` instead of flags.
+:::caution REST is experimental
 
-This setup ensures high availability for your validator. If you encounter errors, join the [Prysm Discord](https://discord.com/invite/prysm) community for support.
+The REST API path (`--enable-beacon-rest-api`) is experimental and not recommended for Mainnet. Use gRPC for production validators.
+
+:::
+
+All flags in both examples go on the **validator client** binary. The beacon node does not require any additional flags to serve its HTTP API — it is enabled by default on port 3500.
+
+### Fallback behavior
+
+Both gRPC and REST use sync-status-aware failover logic:
+
+- The validator checks that each candidate endpoint is reachable **and** fully synced before using it.
+- If the active endpoint becomes unhealthy or unsynced, the validator tries each remaining endpoint in order and stops at the first healthy one.
+
+### Health checks and `--max-health-checks`
+
+The `--max-health-checks` flag (on the **validator client**) controls how many consecutive failed health checks are tolerated before the validator shuts down gracefully.
+
+| Value | Behavior |
+|-------|----------|
+| `0` (default) | Indefinite — the validator never times out due to health check failures and keeps retrying forever. |
+| Positive integer (e.g., `10`) | The validator shuts down after that many consecutive failed checks, allowing a process manager to restart it. |
+
+Example with a finite limit:
+
+```
+./prysm.sh validator \
+  --wallet-dir=/path/to/wallet \
+  --beacon-rpc-provider=localhost:4000,remote-beacon.example.com:4000 \
+  --max-health-checks=10 \
+  --datadir=/path/to/validator/data \
+  --mainnet
+```
+
+While health checks are failing, the validator logs:
+
+```
+Failed health check, beacon node is unresponsive  fails=X maxFails=Y url=...
+```
+
+When the limit is reached:
+
+```
+Maximum health checks reached. Stopping health check routine  maxFails=Y url=...
+```
+
+### Monitoring and testing
+
+- Monitor logs for `Failed health check` and `Health status changed` messages.
+- Use [Prometheus and Grafana](/monitoring-alerts-metrics/grafana-dashboard.md) (enabled via `--monitoring-port=8081`) to track validator performance.
+- Test fallbacks by shutting down one beacon node and confirming the validator continues attesting and proposing via the remaining endpoints.
+
+### Other common flags
+
+- `--graffiti="YourCustomGraffiti"`: Optional [custom block graffiti](/manage-validator/add-graffiti.md).
+- `--wallet-password-file=/path/to/password.txt`: For non-interactive runs.
+- `--enable-doppelganger`: Enables doppelganger protection. If the primary node is down at startup, this may delay the validator — test in a dev environment before enabling on Mainnet.
+- `--tls-cert` / `--tls-key`: For encrypted gRPC connections.
+- `--mainnet`, `--holesky`, or `--sepolia`: Network selection flag.
+
+If you encounter issues, join the [Prysm Discord](https://discord.com/invite/prysm) community for support.


### PR DESCRIPTION
## What's fixed
- Corrected flag attribution: `--enable-beacon-rest-api`, `--beacon-rest-api-provider`, and `--beacon-rpc-provider` are all **validator-client** flags. The page previously told users to start the **beacon node** with `--enable-beacon-rest-api`, which is wrong. The beacon node's HTTP API is on by default (port 3500).
- Clarified the REST vs gRPC fallback setups and where each flag belongs.
- Stated that `--max-health-checks=0` (the default) means **indefinite** health checks.
- Removed PR-number/fork "implementation note" language and the unsupported environment-variable guidance.
- Removed the non-existent `Failover succeeded` log message (kept the real `Failed health check` / `Health status changed`).

## Why
- `--enable-beacon-rest-api` is a validator feature flag, not a beacon-node flag — [config/features/flags.go#L133](https://github.com/OffchainLabs/prysm/blob/49b1c81cd57d6ba8f4a5a1698284750e9e7cc546/config/features/flags.go#L133)
- `--max-health-checks` default is `0`, and shutdown only fires when `maxFails > 0`, so `0` = indefinite — [cmd/validator/flags/flags.go#L405](https://github.com/OffchainLabs/prysm/blob/49b1c81cd57d6ba8f4a5a1698284750e9e7cc546/cmd/validator/flags/flags.go#L405) (default `0` at [#L23](https://github.com/OffchainLabs/prysm/blob/49b1c81cd57d6ba8f4a5a1698284750e9e7cc546/cmd/validator/flags/flags.go#L23)); logic at [health_monitor.go#L57-L66](https://github.com/OffchainLabs/prysm/blob/49b1c81cd57d6ba8f4a5a1698284750e9e7cc546/validator/client/health_monitor.go#L57-L66)
- No `Failover succeeded` log string exists in source (only test-case names); the real health/failover logs live in [validator/client/health_monitor.go](https://github.com/OffchainLabs/prysm/blob/49b1c81cd57d6ba8f4a5a1698284750e9e7cc546/validator/client/health_monitor.go)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
