### PR TITLE
docs: bump Prysm version to v7.1.5 and fix README maintenance drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ vercel
 
 ## Maintenance
 
-When Prysm cuts a new release, update the following files:
+When a new version of Prysm is released, update the following files:
 
-- `docusaurus.config.js` — bump `prysmVersion` (line 1) to the new tag (e.g. `"v7.1.5"`). This drives the version badge and release link in the navbar.
+- `docusaurus.config.js` — bump `prysmVersion` (line 1) to the new tag (e.g., `"v7.1.5"`). This drives the version badge and release link in the navbar.
 - `docs/faq.md` — update any hardcoded version strings in example terminal-output blocks to match the new release.
 - `.node-version` — update if the required Node version changes; keep `README.md` in sync.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Below are steps for initializing and reproducing this portal for development.
 1. The latest version of [Node](https://nodejs.org/en/download/) installed.
 2. npm (comes with Node.js)
 
-   > You have to be on Node >= 8.x.
+   > You have to be on Node >= 20.
 
 ## Installation
 
@@ -21,7 +21,7 @@ Below are steps for initializing and reproducing this portal for development.
 ## Running the development server
 
 1. From the root directory, run the local web server using `npm start`.
-2. Load the example site at http://localhost:3000/prsym/docs if it did not already open automatically. If port 3000 has already been taken, another port will be used. Look at the console messages to see which.
+2. Load the example site at http://localhost:3000/docs/ if it did not already open automatically. If port 3000 has already been taken, another port will be used. Look at the console messages to see which.
 
    You should see the example site loaded in your web browser. There's also a LiveReload server running, and any changes made to the docs and files in the project directory will cause the page to refresh.
 
@@ -51,3 +51,11 @@ Alternatively, you can use the Vercel CLI to deploy from your local machine:
 npm install -g vercel
 vercel
 ```
+
+## Maintenance
+
+When Prysm cuts a new release, update the following files:
+
+- `docusaurus.config.js` — bump `prysmVersion` (line 1) to the new tag (e.g. `"v7.1.5"`). This drives the version badge and release link in the navbar.
+- `docs/faq.md` — update any hardcoded version strings in example terminal-output blocks to match the new release.
+- `.node-version` — update if the required Node version changes; keep `README.md` in sync.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,4 +1,4 @@
-var prysmVersion = "v7.1.0";
+var prysmVersion = "v7.1.5";
 
 module.exports = {
     title: 'Prysm',


### PR DESCRIPTION
## What's fixed
- Bumped the displayed Prysm version `v7.1.0` → `v7.1.5` (`docusaurus.config.js`).
- Updated the README Node requirement `>= 8.x` → `>= 20` to match the repo's `.node-version`.
- Fixed the README local-URL typo (`/prsym/docs` → the correct `baseUrl`).
- Added a short release-bump checklist to the README.

## Why
- The latest Prysm release is v7.1.5 — [github.com/OffchainLabs/prysm/releases/tag/v7.1.5](https://github.com/OffchainLabs/prysm/releases/tag/v7.1.5)
- Node version and base URL are docs-repo facts: `.node-version` pins Node `20`, and `docusaurus.config.js` sets `baseUrl: '/docs/'` (the old `prsym` URL was a misspelling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
