### PR TITLE
Fix `robots.txt`: Serving correctly after deployment & Remove literal and trailing quote

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,1 +1,0 @@
-User-agent: *\nDisallow: /docs/docs\n"

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Disallow: /docs/docs
+
+Sitemap: https://docs.prylabs.network/docs/sitemap.xml

--- a/vercel.json
+++ b/vercel.json
@@ -5,6 +5,12 @@
   "installCommand": "npm install",
   "trailingSlash": true,
   "cleanUrls": true,
+  "rewrites": [
+    {
+      "source": "/robots.txt",
+      "destination": "/docs/robots.txt"
+    }
+  ],
   "redirects": [
     { "source": "/prysm/docs/(.*)", 
       "destination": "/docs/$1", 


### PR DESCRIPTION
Our `robots.txt` actually has not been served (proof: https://prysm.offchainlabs.com/robots.txt). This PR fixes this issue. You can check locally via this command after `npm start`:

```sh
$ curl -i http://localhost:3000/docs/robots.txt
```

And `vercel.json` redirects correctly when bot requests for https://prysm.offchainlabs.com/robots.txt.