### PR TITLE
Serve markdown via Accept header content negotiation

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -1,0 +1,20 @@
+// Content negotiation: serve the plugin-generated .md when a client asks for markdown.
+// Must be Edge Middleware (not a vercel.json rewrite) because /docs/<page>/ already
+// resolves to a static index.html, and top-level rewrites don't override existing files.
+import { rewrite, next } from '@vercel/edge';
+
+export const config = { matcher: '/docs/:path*' };
+
+export default function middleware(request) {
+  const accept = request.headers.get('accept') || '';
+  if (!accept.includes('text/markdown')) return next();
+
+  const url = new URL(request.url);
+  const { pathname } = url;
+  // skip anything already targeting a file (.md, images, js/css) — only page routes get rewritten
+  if (/\.[a-z0-9]+$/i.test(pathname)) return next();
+
+  url.pathname =
+    pathname === '/docs/' ? '/docs/index.md' : pathname.replace(/\/$/, '') + '.md';
+  return rewrite(url);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "name": "prysm-documentation",
       "dependencies": {
         "@docusaurus/theme-search-algolia": "3.10.1",
+        "@vercel/edge": "^1.3.1",
         "classnames": "^2.3.1",
         "clsx": "1.1.1",
         "docusaurus-lunr-search": "3.6.0"
@@ -5682,6 +5683,12 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.2.tgz",
       "integrity": "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==",
       "license": "ISC"
+    },
+    "node_modules/@vercel/edge": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@vercel/edge/-/edge-1.3.1.tgz",
+      "integrity": "sha512-k0tKWeYEWOv6qU6+Z8+hv2Nt/u3vFHRZdB0uvwE0DxoddU/5kWX/Chu8F6ojvqmRlnZwuX/7kyZFVeCP6DxqBg==",
+      "license": "Apache-2.0"
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@docusaurus/theme-search-algolia": "3.10.1",
+    "@vercel/edge": "^1.3.1",
     "classnames": "^2.3.1",
     "clsx": "1.1.1",
     "docusaurus-lunr-search": "3.6.0"

--- a/vercel.json
+++ b/vercel.json
@@ -11,6 +11,16 @@
       "destination": "/docs/robots.txt"
     }
   ],
+  "headers": [
+    {
+      "source": "/docs/:path*",
+      "headers": [{ "key": "Vary", "value": "Accept" }]
+    },
+    {
+      "source": "/docs/:path*.md",
+      "headers": [{ "key": "Content-Type", "value": "text/markdown; charset=utf-8" }]
+    }
+  ],
   "redirects": [
     { "source": "/prysm/docs/(.*)", 
       "destination": "/docs/$1", 


### PR DESCRIPTION
Should be merged after #1209 

Part of
- #1201 

After this PR, our documenation can also serve pure markdown. Parsing HTML is often token-consuming, so AI agents try to negotiate with the target to receive the content as markdown.

Verify with following command:

```bash
curl -s -D - -H "Accept: text/markdown" "https://prysm-documentation-git-feat-serve-markdown-offchain-labs1.vercel.app/docs/faq/" | head -20
```