### PR TITLE
ci: add Prysm version update workflow

### DIFF
--- a/.github/workflows/update-prysm-version.yml
+++ b/.github/workflows/update-prysm-version.yml
@@ -1,0 +1,37 @@
+name: Update Prysm version
+
+# Updates the version badge and release link in docusaurus.config.js, then
+# opens a PR when Prysm publishes a newer release.
+on:
+  schedule:
+    - cron: '0 8 * * 1' # Mondays 08:00 UTC
+  workflow_dispatch: {}
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: prysm
+        run: |
+          tag=$(curl -sf https://api.github.com/repos/OffchainLabs/prysm/releases/latest | grep '"tag_name"' | cut -d'"' -f4)
+          [[ "$tag" =~ ^v[0-9]+(\.[0-9]+){2}(-[0-9A-Za-z.-]+)?$ ]] || exit 1
+          sed -i '1s/^var prysmVersion = "[^"]*";$/var prysmVersion = "'"$tag"'";/' docusaurus.config.js
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: 'chore: update Prysm version to ${{ steps.prysm.outputs.tag }}'
+          title: 'chore: update Prysm version to ${{ steps.prysm.outputs.tag }}'
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          body: |
+            Automated update of `prysmVersion` in `docusaurus.config.js`, created by
+            the `update-prysm-version` workflow.
+          base: master
+          branch: automated/update-prysm-version
+          delete-branch: true


### PR DESCRIPTION
Adds a weekly/manual workflow that updates prysmVersion from Prysm's latest release and opens an automated PR.

PR will be open like #1216 