### PR TITLE
Refresh developer reference

### DIFF
--- a/docs/contribute/contribution-guidelines.md
+++ b/docs/contribute/contribution-guidelines.md
@@ -19,7 +19,7 @@ Once you are a bit more familiar with the concepts behind Ethereum and are ready
 To develop Prysm, you'll need the following:
 
 - A modern Windows, macOS, or Linux operating system
-- Go 1.25 version installed, download and install [here](https://golang.org/dl/)
+- The Go version declared in Prysm's [`go.mod`](https://github.com/OffchainLabs/prysm/blob/develop/go.mod), installed from [go.dev](https://go.dev/dl/)
 - The `git` package installed
 - A code editor such as [Visual Studio Code](https://code.visualstudio.com/download) or Jetbrains' [Goland IDE](https://www.jetbrains.com/go/) or your preferred one
 
@@ -42,7 +42,7 @@ go version
 
 Example output:
 ```sh
-go version go1.25.0 darwin/arm64
+go version go1.x.y darwin/arm64
 ```
 
 ### Building and testing Prysm with Go
@@ -151,13 +151,13 @@ Each time you begin a set of changes, ensure that you are working on a new branc
 To create a local branch for `git` to checkout, issue the command:
 
 ```sh
-    git checkout -b feature-in-progress-branch
+    git switch -c feature-in-progress-branch
 ```
 
 To checkout a branch you have already created:
 
 ```sh
-    git checkout feature-in-progress-branch
+    git switch feature-in-progress-branch
 ```
 
 **Preparing your commit**
@@ -209,14 +209,14 @@ The code from the Prysm repository is inserted between `<<<` and `===` while the
 When you are ready, use git push to move your local copy of the changes to your fork of the repository on GitHub.
 
 ```sh
-    git push myrepo feature-in-progress-branch
+    git push myprysmrepo feature-in-progress-branch
 ```
 
 #### Opening a pull request
 
 :::info
 
-If your change is user facing, ensure that your changeset includes an entry to the `CHANGELOG.md` file!
+Follow the repository's current pull-request template and changelog guidance.
 
 :::
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -56,7 +56,7 @@ Slashing is a way for the network to penalize validator actions that can be harm
 
 The most common way validators get slashed is by **running the same validator key in two separate validator client processes at the same time**. This will absolutely get you slashed. Some stakers try to create complicated failover scenarios without realizing the risk this entails, do not do this. If you already got slashed, you will leak funds for a while until you are forcefully exited from the validator registry. Thankfully, slashing penalties are relatively small. If you are slashed, you should keep performing your validator duties until you are exited. After being exited, you can withdraw your remaining validator balance using our [withdrawal guide](/manage-validator/withdraw-validator.md).
 
-Our team prepared a blog post on [slashing prevention tips](https://medium.com/prysmatic-labs/eth2-slashing-prevention-tips-f6faa5025f50) you can read to avoid slashings in the future.
+See our [slashing protection guide](/backup-and-migration/slashing-protection.md) before moving a validator or changing its setup.
 
 ### Running Prysm
 
@@ -169,7 +169,7 @@ Depositing into Ethereum as a validator is a multi-step process that can require
 
 #### I made a correct deposit and my validator status in Prysm is still UNKNOWN, what’s going on?
 
-There are a few possibilities. (1) your deposit has not yet been processed by beacon nodes. It takes a while for the beacon node to be able to process logs from the execution chain by design. If you have already waited a few hours and no luck, there is a chance that (2) your deposit did not verify (that is, you used some other method of creating the deposit than our recommended, standard way on the Ethereum launchpad), or (3) you never actually sent a deposit to the right contract address
+There are a few possibilities. Your deposit may not yet have been processed, may be waiting in the activation queue, or may have been submitted incorrectly. Verify it on the [Ethereum staking launchpad](https://launchpad.ethereum.org/) and confirm that the deposit was sent to the correct network and contract.
 
 #### How can I move my validator to a different computer without getting slashed?
 
@@ -207,7 +207,7 @@ If you have a fully synced beacon node, you can fetch your account balance via t
 
 #### Why are some validators making a lot more money than others?
 
-If you look at the [validator leaderboard](https://beaconcha.in/validators/leaderboard), there are some validators at the top that seem to be doing a lot better than others. The reason being that either they (a) got lucky with being assigned to propose more blocks than other validators, or (b) they caught slashable offenses in the network and packed them into their blocks. Slashings are meant to be rare, and Prysm's slasher by default broadcasts slashings it finds to the network so that validators do not selfishly hold on to them. You can actually disable this to selfishly withhold slashings with the `--disable-broadcast-slashings` flag in your beacon node, although don't expect to get rich from slashing other validators. 
+Block-proposal opportunities are random, and proposal rewards can make short-term leaderboard results vary substantially. Do not rely on a slasher for income; it is an optional service enabled explicitly with Prysm's `--slasher` flag.
 
 Overall, keep in mind that no one has an extra advantage as a validator compared to others. Block proposal opportunities are random and it does not matter how powerful your hardware is. A lot of the times the validators near the top simply got lucky.
 

--- a/docs/learn/concepts/keys-wallets-accounts.md
+++ b/docs/learn/concepts/keys-wallets-accounts.md
@@ -87,4 +87,4 @@ If you're encountering an unexpected issue that causes your client to crash or t
 
 #### How can I stop being a validator?
 
-You can stop being a validator by issuing a **voluntary exit**, which is a special type of object included in the Ethereum beacon chain that signifies your validator is ready to stop validating and securely exit the validator set. Although during phase 0 of Ethereum consensus, you will **not** be able to withdraw your staking rewards, you can still issue a voluntary exit. You can find instructions for this process [here](/manage-validator/exit-a-validator.md).
+You can stop being a validator by issuing a **voluntary exit**, which signals that your validator should leave the active set. After the exit is processed, the protocol withdraws the validator's balance to its configured execution address. Follow the [exit guide](/manage-validator/exit-a-validator.md) and [withdrawal guide](/manage-validator/withdraw-validator.md).

--- a/docs/learn/concepts/nodes-and-networks.md
+++ b/docs/learn/concepts/nodes-and-networks.md
@@ -25,7 +25,7 @@ An Ethereum **node** is a running instance of Ethereum's client software. This s
 
 There are two primary types of nodes in Ethereum: **execution nodes** and **beacon nodes**. Colloquially, a "node" refers to an execution node and beacon node working together. Nodes establish connections with other nodes running on other computers, forming a decentralized peer-to-peer network that processes Ethereum blocks and transactions.
 
-When users stake 32 `ETH` to participate in Ethereum's proof-of-stake consensus mechanism, they use a separate piece of software called a **validator client**, which connects to their Prysm beacon node. This is special piece of software that manages validator keys and duties such as producing new blocks and voting on others' proposed blocks. Validator clients connect to the Ethereum network through beacon nodes, which depend on execution nodes:
+Users that operate validators use a separate **validator client**, which connects to a beacon node. It manages validator keys and duties such as proposing blocks and attesting to others' blocks. Validator clients connect to the Ethereum network through beacon nodes, which depend on execution nodes:
 
 <br />
 
@@ -53,7 +53,7 @@ When users stake 32 `ETH` to participate in Ethereum's proof-of-stake consensus 
       </tr>
       <tr>
         <td><strong>Validator</strong></td>
-        <td>Validator clients are specialized software that let people stake 32 `ETH` as collateral within Ethereum's <strong>consensus layer</strong>. Validators are responsible for proposing blocks within Ethereum's proof-of-stake consensus mechanism, having fully replaced proof-of-work miners after <a href='https://ethereum.org/en/upgrades/merge/'>The Merge</a>. <br /> <br />A validator will talk only to a local beacon node. A validator's beacon node tells the validator what work to do, and broadcasts the validator's work to the Ethereum network as the validator performs its duties.</td>
+        <td>Validator clients are specialized software that manage one or more validators in Ethereum's <strong>consensus layer</strong>. Validators propose blocks and attest to blocks proposed by others. A validator client requests duties from a beacon node and submits signed results through it.</td>
       </tr>
     </tbody>
 </table>
@@ -109,7 +109,7 @@ No. All Ethereum network participants need to run both an execution node and a b
 Mining is a proof-of-work consensus mechanism. Ethereum's consensus is now driven by a proof-of-stake mechanism, which replaces miners with validators.
 
 #### Where do slashers come into play?
-Slashers, like validators, use specialized pieces of consensus-layer client software to fulfill a critical responsibility for the Ethereum network. Slashers attempt to detect and punish malicious validators. Learn more by reading our [Slasher documentation](/configure-prysm/run-a-slasher.md).
+Slashers detect slashable validator messages and submit evidence to the network. They are optional and are not required to operate a validator. Learn more in the [slasher documentation](/configure-prysm/run-a-slasher.md).
 
 #### How do I get testnet `ETH`?
 You can request testnet `ETH` from public faucets. For Sepolia, try the [Sepolia PoW Faucet](https://sepolia-faucet.pk910.de/) or [Alchemy's Sepolia Faucet](https://sepoliafaucet.com/). For Hoodi, check the [Hoodi GitHub repository](https://github.com/eth-clients/hoodi) for available faucets. You can also ask the community for testnet `ETH` on either the [Prysm Discord server](https://discord.gg/qEZK94mFXP) or on [r/ethstaker](https://www.reddit.com/r/ethstaker).

--- a/docs/learn/concepts/validator-lifecycle.md
+++ b/docs/learn/concepts/validator-lifecycle.md
@@ -46,7 +46,7 @@ If a slashable event is included in a block while a validator is either `ACTIVE`
   #### [Missed Attestation Penalties](https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#rewards-and-penalties-1)
   A penalty equivalent to that incurred by an inactive validator, issued every epoch until the validator leaves the exit queue
   #### [Attack Multiplier Penalty](https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#slashings)
-  A penalty proportional to three times the number of other slashings in the past 8192 epochs (4 <abbr title="An eek is a period of 2048 epochs (~9.1 days), it is short for Ethereum week">eeks</abbr>, ~36 days), applied 4096 epochs (2 eeks, ~18 days) after the slashing event was first included in a block. Under normal circumstances this penalty is quite small, however in the event that a large number of slashings occur in a short time frame, this penalty can be as high as 32 `ETH`.
+  An additional correlation penalty is applied after the protocol's slashing window. Its amount depends on other slashings in that window and the validator's effective balance; see the current [consensus specification](https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#slashings) for the formula.
 
 ## `EXITED` State
-In the case that the validator has reached the exited state voluntarily, the funds will become withdrawable after 256 epochs (~27 hours). If the validator was slashed, this delay is extended to 4 eeks (2048 epochs*4 or ~36 days). If a slashable event is included in a block before funds have been withdrawn, the validator will move back to the `SLASHING` state causing withdrawal delays to reset.
+An exited validator becomes withdrawable after its protocol-defined withdrawal delay and any exit queue. Slashed validators have a longer delay. The current timings are defined by the [consensus specification](https://github.com/ethereum/consensus-specs).

--- a/docs/learn/tools/bazel.md
+++ b/docs/learn/tools/bazel.md
@@ -63,7 +63,7 @@ A large problem in monorepos is, of course, dealing with dependency management. 
 
 Bazel's query tool allows you to create graph visualizations of your entire dependency tree, making it a lot more robust and standardized compared to other methods of managing dependencies in a project.
 
-All dependencies in the Prysm monorepo live in a file called `deps.bzl` at the top-level of the repository [here](https://github.com/OffchainLabs/prysm/blob/develop/deps.bzl).
+Go dependencies are declared in [`go.mod`](https://github.com/OffchainLabs/prysm/blob/develop/go.mod); Bazel dependency definitions live in the repository's Bazel configuration files.
 
 ### How to add new dependencies
 
@@ -73,9 +73,7 @@ Adding new dependencies to Prysm requires specific changes. We have prepared a c
 
 A common question we get is: "where are Prysm's Dockerfiles?". With Bazel, we get a ton of benefits in terms of optimizing our deployment and release process. In particular, we use [`bazel rules docker`](https://github.com/bazelbuild/rules_docker) which provides us the ability to specify a base, barebones image, and essentially builds our binary and creates a Docker container as a simple wrapper over our binaries. 
 
-We do not write our own Dockerfiles, as Bazel provides us a more sandboxed, simple experience with all of its benefits. To see an example use of `bazel rules docker` for how we build a particular package, see [here](https://github.com/OffchainLabs/prysm/blob/aa389c82a157008741450ba1e04d898924734432/tools/bootnode/BUILD.bazel#L36). 
-
-To read comprehensive instructions on how to build Prysm's docker images for your own use, see [here](/install-prysm/install-with-bazel.md).
+See the repository's current build and release configuration for container-image details; this page covers the developer build workflow.
 
 ## Building Production Releases
 
@@ -84,7 +82,7 @@ To read comprehensive instructions on how to build Prysm's docker images for you
 Everything in Prysm can be built with Bazel using
 
 ```sh
-bazel build /...
+bazel build //...
 ```
 
 For example, the beacon node can be built with
@@ -93,12 +91,12 @@ For example, the beacon node can be built with
 bazel build //cmd/beacon-chain --config=release
 ```
 
-The `--config=release` will apply all compile-time optimizations to the code, and build everything including C dependencies and our cryptography from source. Every package in the Prysm monorepo can be build with
+The `--config=release` applies the release build configuration. Every package in the Prysm monorepo can be built with
 
 ```sh
-bazel build
+bazel build //...
 ```
 
 ### With Go
 
-Building Prysm with Go is possible, but it will use precompiled cryptography to build the final executable. Additionally, it will not perform the compile-time optimizations Bazel does, and can have unexpected issues as you are relinquishing reproducible, hermetic builds which Bazel provides. We always recommend Bazel as the only way to run Prysm if you are planning on running it.
+Building with Go is useful for local development and editor tooling. Use the project's documented release process for production artifacts.

--- a/docs/security-best-practices.md
+++ b/docs/security-best-practices.md
@@ -8,7 +8,7 @@ import {HeaderBadgesWidget} from '@site/src/components/HeaderBadgesWidget.js';
 
 <HeaderBadgesWidget />
 
-Ethereum's transition to proof-of-stake is made possible by validators who each stake 32 `ETH` into the [validator deposit contract](/learn/dev-concepts/validator-deposit-contract.md). These validators accept the responsibility to uphold the integrity of the Ethereum network in exchange for staking rewards.
+Ethereum proof-of-stake is secured by validators that make an initial deposit and perform consensus duties in exchange for staking rewards. The usual initial deposit is 32 `ETH`; validators using compounding credentials can have a higher maximum effective balance.
 
 Validators are rewarded for maintaining highly available, trustworthy validator client instances. The security best practices in this guide will help you fulfill this responsibility by helping you minimize risk across a variety of security aspects. Within each aspect, you'll find **recommended**, **advanced**, and **Linux-specific** guidance.
 
@@ -20,7 +20,7 @@ Note that this document is subject to the [Prysm Terms of Service](https://githu
 The following principles apply generally to staking security:
 
  - **Keep it simple**. Over-engineered solutions tend to increase risk.
- - **Stay up to date**. At a minimum, join the [prysm-dev Google Group](https://groups.google.com/g/prysm-dev) to receive important updates related to client security and maintenance. We encourage all stakers to join the [Prysm Discord server](https://discord.gg/qEZK94mFXP) and [r/ethstaker](https://www.reddit.com/r/ethstaker). Visit the [Learning Resources](#learning-resources) section at the end of this guide for a short list of resources that we recommend visiting periodically.
+ - **Stay up to date**. Watch the [Prysm releases](https://github.com/OffchainLabs/prysm/releases) and security advisories, and follow the [Prysm Discord server](https://discord.gg/qEZK94mFXP) and [r/ethstaker](https://www.reddit.com/r/ethstaker) for operational updates.
  - **Testnet first**. Harden your configuration using testnet [<a href='#footnote-1'>1</a>] before staking with real `ETH` on mainnet.
  - **Simulate risk events**. For each of the aspects within this document, simulate risk events and document your own risk mitigation plans. You can use the [risk mitigation worksheet](#mitigation-worksheet) located at the end of this guide.
  - **Proactively manage risk** You can't completely eliminate risk, but you can minimize it by following the best practices within this guide.
@@ -181,10 +181,10 @@ Footnotes:
 <strong id='footnote-1'>1</strong>. Learn more about the Hoodi testnet <a href='https://hoodi.launchpad.ethereum.org/'>here on Ethereum.org</a>. <br />
 <strong id='footnote-2'>2</strong>. BitMex recently posted research that provides hard numbers on penalties and rewards: <a href='https://blog.bitmex.com/ethereums-proof-of-stake-system-calculating-penalties-rewards/'>Ethereum's Proof of Stake System - Calculating Penalties and Rewards</a>. Collin Myers has also created an <a href='https://docs.google.com/spreadsheets/d/15tmPOvOgi3wKxJw7KQJKoUe-uonbYR6HF7u83LR5Mj4/edit#gid=1018097491'>Ethereum calculator</a>. <br />
 <strong id='footnote-3'>3</strong>. See <a href='https://www.reddit.com/r/ethstaker/comments/nnwfx1/why_you_should_stop_worrying_about_your/'>Why you should stop worrying about your validator's uptime and start embracing the chaos instead</a>. <br />
-<strong id='footnote-4'>4</strong>. See <a href='https://medium.com/prysmatic-labs/eth2-slashing-prevention-tips-f6faa5025f50'>Eth2 Slashing Prevention Tips</a> to learn more about slashing.<br />
+<strong id='footnote-4'>4</strong>. See the <a href='/backup-and-migration/slashing-protection.md'>slashing protection guide</a> before moving validator keys.<br />
 <strong id='footnote-5'>5</strong>. <a href='https://www.beaconcha.in'>BeaconChain</a> has a mobile app that will alert you when your validator state changes. <br />
 <strong id='footnote-6'>6</strong>. See <a href='https://www.youtube.com/watch?v=txgOVDTemPQ'>How to monitor your ETH 2 Validator with Google Cloud</a> for a demonstration of this type of solution. <br />
-<strong id='footnote-7'>7</strong>. See <a href='https://medium.com/prysmatic-labs/eth2-slashing-prevention-tips-f6faa5025f50'>Eth2 Slashing Prevention Tips</a> by Raul Jordan. <br />
+<strong id='footnote-7'>7</strong>. See the <a href='/backup-and-migration/slashing-protection.md'>slashing protection guide</a>. <br />
 <strong id='footnote-8'>8</strong>. See <a href='https://www.reddit.com/r/ethstaker/comments/oa6m2o/my_validator_got_slashed/'>this discussion on Reddit</a> for an example of how an honest scripting mistake can result in slashing. The Ethereum ecosystem is growing quickly - this requires all participants to exercise an abundance of caution. <br />
 <strong id='footnote-9'>9</strong>. CoinCashew demonstrates firewall configuration best practices <a href='https://www.coincashew.com/coins/overview-eth/archived-guides/guide-or-how-to-setup-a-validator-on-eth2-mainnet/part-i-installation/step-2-configuring-node#enable-firewall'>here</a>. <br />
 <strong id='footnote-10'>10</strong>. CoinCashew demonstrates root account administration <a href='https://www.coincashew.com/coins/overview-eth/testnet-hoodi/step-2-configuring-node'>here</a>. <br />

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -14,7 +14,7 @@ This page houses definitions to the various technical terms found throughout thi
 The process of voting on the validity of newly created blocks on the beacon chain.
 
 #### Beacon chain
-The consensus chain that maintains Ethereum's consensus state, coordinates validators, and agrees on the canonical chain. Ethereum does not use the originally proposed execution shard chains; it scales rollups with blob data availability.
+The consensus chain, which maintains Ethereum's consensus state, coordinates validators and agrees on the canonical chain. Ethereum does not use the originally proposed execution shard chains; it scales rollups with blob data availability.
 
 #### Beacon node
 Beacon nodes use beacon node client software to coordinate Ethereum's proof-of-stake consensus. A beacon node will talk to other beacon nodes via peer-to-peer networking, to a local execution node, and (optionally) to a local validator.
@@ -69,10 +69,10 @@ JSON Web Token (JWT) is an industry-standard method for decoding, verifying, and
 A data storage paradigm designed for storing, retrieving, and managing hash tables.
 
 #### Partial validator withdrawal
-An automatic withdrawal of balance above a validator's maximum effective balance to its execution address. The validator remains active. The protocol limits how many withdrawals are processed in each block.
+An automatic withdrawal of the balance above a validator's maximum effective balance to its execution address. The validator remains active. The protocol limits the number of withdrawals processed in each block.
 
 #### Proof-of-Stake \(PoS\)
-Ethereum's consensus mechanism, in which validators stake ETH and are selected to propose and attest to blocks. It replaced proof-of-work on Ethereum mainnet.
+Ethereum's consensus mechanism, in which validators stake ETH and are selected to propose and attest to blocks. It replaced proof-of-work on the Ethereum mainnet.
 
 #### Proposal \(propose\) <a id="propose"></a>
 The process of creating and adding new blocks to the beacon chain.

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -14,25 +14,25 @@ This page houses definitions to the various technical terms found throughout thi
 The process of voting on the validity of newly created blocks on the beacon chain.
 
 #### Beacon chain
-The Beacon Chain maintains the network's state and manages the validators involved in the consensus process. It oversees the shard chains of Ethereum, which operate in parallel to the main chain, providing a more efficient and decentralized system.
+The consensus chain that maintains Ethereum's consensus state, coordinates validators, and agrees on the canonical chain. Ethereum does not use the originally proposed execution shard chains; it scales rollups with blob data availability.
 
 #### Beacon node
 Beacon nodes use beacon node client software to coordinate Ethereum's proof-of-stake consensus. A beacon node will talk to other beacon nodes via peer-to-peer networking, to a local execution node, and (optionally) to a local validator.
 
 #### BLS key
-Your validators use a key format known as [BLS](/learn/dev-concepts/bls-cryptography.md), which is used exclusively for staking. Validators have four kinds of BLS keys: validator public key, validator private key, withdrawal public key, and withdrawal private key. only the validator public key can be viewed on staking explorers such as [https://beaconcha.in](https://beaconcha.in), and private keys, which are secret, are used for signing. Not to be confused with an Ethereum address. The validator mnemonic can be used to access all 4 keys which are important for setting the Ethereum address for withdrawing.
+Validators use [BLS](/learn/dev-concepts/bls-cryptography.md) key pairs to sign consensus messages. A validator public key is visible on staking explorers; its private key must remain secret. It is not an Ethereum execution address.
 
 #### BLS to Execution Change
-In order to withdraw your validator, Ethereum needs to associate an **Ethereum execution address** with your validator’s **keys**. Underneath the hood, submitting a bls-to-execution-change (withdrawal) request updates the [withdrawal credentials](https://github.com/ethereum/consensus-specs/blob/master/specs/phase0/validator.md#withdrawal-credentials) which tells Ethereum “I want to withdraw my validator balance to this specific Ethereum address”. When you see the terms BLS to Execution or bls_to_exec used, it refers to this action. **note:** withdrawal request and bls-to-execution-change are used interchangeably.
+A BLS-to-execution change updates a validator's withdrawal credentials from BLS (`0x00`) to an Ethereum execution address (`0x01`). It is distinct from an execution-layer withdrawal request, which is used for exits, partial withdrawals, and consolidations after Electra.
 
 #### Canonical head block
-The latest block to be proposed on a blockchain.
+The block selected by fork choice as the head of the canonical chain.
 
 #### Consensus
 A protocol that governs how to choose validators to propose or validate blocks and process transactions. In cases where multiple blocks are at the head of the chain, a fork-choice mechanism selects the "heaviest" chain based on the number of validators voting for the blocks, weighted by the amount of staked ether.
 
 #### Checkpoint
-An endpoint, specific to the Consensus layer, that can include state and verification of the Ethereum blockchain. It allows syncing a node to be faster and takes less space than syncing from genesis.
+A consensus-layer epoch boundary used for finality and attestation votes. A checkpoint sync is a separate bootstrap method that obtains a trusted recent state to accelerate initial sync.
 
 #### Consensus layer
 The consensus client, or Beacon Node, implements the proof-of-stake algorithm, allowing the network to reach agreement based on verified data from the execution client. A validator can also be added to the client, enabling a node to help secure the network.
@@ -60,7 +60,7 @@ A function evaluated by the client that takes, as input, the set of blocks and o
 The process of withdrawing your entire stake on Ethereum, exiting your validator, and withdrawing your entire balance to an Ethereum address of your choosing. Full validator withdrawals need a validator to exit first, which can take time depending on how large the exit queue is. Performing a full withdrawal requires submitting a voluntary exit first.
 
 #### HD wallet mnemonic
-Refer to [Validator mnemonic](#validator-mnemonic].
+Refer to [Validator mnemonic](#validator-mnemonic).
 
 #### JWT token
 JSON Web Token (JWT) is an industry-standard method for decoding, verifying, and generating tokens that securely represent claims between two parties. It serves as a reliable and effective solution for ensuring secure communication (between the Execution and Consensus layers).
@@ -69,10 +69,10 @@ JSON Web Token (JWT) is an industry-standard method for decoding, verifying, and
 A data storage paradigm designed for storing, retrieving, and managing hash tables.
 
 #### Partial validator withdrawal
-The process of withdrawing your validator’s **earnings** only. That is, if you're staking 33.3 `ETH`, you can withdraw 1.3 `ETH` using a partial withdrawal. Your validator does **not** need to exit, and you will continue to validate normally. Partial withdrawals do not go through an exit queue, but will only be processed at a maximum of 16 validators at a time per block.
+An automatic withdrawal of balance above a validator's maximum effective balance to its execution address. The validator remains active. The protocol limits how many withdrawals are processed in each block.
 
 #### Proof-of-Stake \(PoS\)
-The PoS concept states that a person can mine or validate block transactions according to how many coins they hold. This is a vastly improved iteration on Proof-of-Work \(PoW\), which relies on immense amounts of computational power to advance the state of the blockchain.
+Ethereum's consensus mechanism, in which validators stake ETH and are selected to propose and attest to blocks. It replaced proof-of-work on Ethereum mainnet.
 
 #### Proposal \(propose\) <a id="propose"></a>
 The process of creating and adding new blocks to the beacon chain.
@@ -87,7 +87,7 @@ A slasher is software that detects slashable events from validators and reports 
 The person or entity managing Ethereum validators.
 
 #### Validator
-Most often refers to a [validator client](#validator-client) instance, but can also refer to an individual that is physically managing a validator client, or the key used for staking.
+An on-chain consensus participant identified by a BLS public key. A [validator client](#validator-client) is the software that manages one or more validators.
 
 #### Validator client
 Allows users running the software to stake `ETH`, propose and validate new blocks, earn staking rewards, and staking tips.
@@ -99,7 +99,7 @@ A unique numeric ID assigned to a validator when activated. You can see this val
 A mnemonic in this context is the 24 word secret that you received upon creating your validator(s), which is the ultimate credential that gives you access to withdrawing your validator(s). For many, this was generated when they first interacted with the Ethereum staking CLI to prepare their validator deposits. We will refer to this as your validator mnemonic throughout this document
 
 #### Validator seed phrase
-Refer to [Validator mnemonic](#validator-mnemonic].
+Refer to [Validator mnemonic](#validator-mnemonic).
 
 #### Validator withdrawal credentials
 Each validator has data known as “withdrawal credentials” which can be fetched from your beacon node or from a block explorer such as [https://beaconcha.in](https://beaconcha.in) or [https://beaconscan.com](https://beaconscan.com) by looking at the “deposits” tab and seeing your credentials there. You will need these for this guide.

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -87,7 +87,7 @@ A slasher is software that detects slashable events from validators and reports 
 The person or entity managing Ethereum validators.
 
 #### Validator
-An on-chain consensus participant identified by a BLS public key. A [validator client](#validator-client) is the software that manages one or more validators.
+An onchain consensus participant identified by a BLS public key. A [validator client](#validator-client) is the software that manages one or more validators.
 
 #### Validator client
 Allows users running the software to stake `ETH`, propose and validate new blocks, earn staking rewards, and staking tips.


### PR DESCRIPTION
- Update Go version guidance to point at `go.mod`/go.dev instead of a hardcoded version
- Replace deprecated `git checkout` usage with `git switch` in contribution guidelines
- Replace outdated Medium slashing-prevention links with the in-repo slashing protection guide
- Correct validator/beacon-node/slasher descriptions in nodes-and-networks and terminology docs to reflect current post-Merge, post-Electra terminology (e.g. BLS-to-execution change, partial withdrawals, checkpoints)
- Fix broken anchor links (`#validator-mnemonic]` → `#validator-mnemonic)`) and a stray `bazel build /...` typo
- Remove references to removed `deps.bzl`/Dockerfile specifics in bazel.md, pointing instead to current Bazel config and release process docs