### PR TITLE
Remove @syjn99 as a co-author of automated CLI reference commit

### DIFF
--- a/.github/workflows/update-cli-reference.yml
+++ b/.github/workflows/update-cli-reference.yml
@@ -35,6 +35,8 @@ jobs:
         with:
           commit-message: 'chore: update CLI reference from Prysm ${{ steps.prysm.outputs.tag }}'
           title: 'chore: update CLI reference from Prysm ${{ steps.prysm.outputs.tag }}'
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           body: |
             Automated update of the command-line options reference from
             `cli.prylabs.network`, created by the `update-cli-reference` workflow.


### PR DESCRIPTION
Unlike `.github/workflows/update-prysm-version.yml`, `.github/workflows/update-cli-reference.yml` writes a commit that includes @syjn99 as a co-author. (e.g., #1231) This PR removes @syjn99 as a co-author for all CLI reference commits from now.